### PR TITLE
Follow-up: address copilot review comments for #3

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -17,7 +17,7 @@ import random
 import time
 from typing import Any, Dict, List
 
-import simulator  # 同时触发 tuner.initialize_runtime_config，填充 CONFIG
+import simulator  # 用于模拟加热系统和随机性
 from pid_safety import (
     DEFAULT_CONVERGENCE_RULES,
     apply_pid_guardrails,
@@ -27,7 +27,7 @@ from pid_safety import (
     pid_equals,
     should_rollback_to_best,
 )
-from tuner import AdvancedDataBuffer, CONFIG, LLMTuner, TuningHistory
+from tuner import AdvancedDataBuffer, CONFIG, LLMTuner, TuningHistory, initialize_runtime_config
 
 
 DEFAULT_CASES = ("baseline", "fallback", "llm")
@@ -208,6 +208,8 @@ def print_summary(results: List[Dict[str, Any]]):
 
 
 def main():
+    # 显式初始化调参运行时配置，而不是依赖 simulator 的导入副作用
+    initialize_runtime_config(verbose=False)
     parser = argparse.ArgumentParser(description="LLM PID 调参 benchmark")
     parser.add_argument(
         "--cases",

--- a/firmware.cpp
+++ b/firmware.cpp
@@ -230,18 +230,32 @@ void sendDataToSerial() {
 void processSerialCommand() {
     // 静态缓冲区：逐字节非阻塞积累，避免 readStringUntil() 阻塞控制循环
     static char    cmd_buf[80];
-    static uint8_t cmd_len = 0;
+    static uint8_t cmd_len      = 0;
+    static bool    cmd_overflow = false;  // 标记本行是否发生缓冲区溢出
 
     while (Serial.available()) {
         char c = (char)Serial.read();
         if (c == '\r') continue;               // 兼容 Windows CRLF
         if (c != '\n') {
-            if (cmd_len < sizeof(cmd_buf) - 1) // 防缓冲区溢出，超长字节静默丢弃
-                cmd_buf[cmd_len++] = c;
+            if (!cmd_overflow) {
+                if (cmd_len < sizeof(cmd_buf) - 1) {
+                    cmd_buf[cmd_len++] = c;
+                } else {
+                    cmd_overflow = true;  // 缓冲区满，标记溢出，后续直到换行都丢弃
+                }
+            }
             continue;
         }
 
-        // 收到换行符 —— 处理完整命令行
+        // 收到换行符 —— 如果发生过溢出，则整行丢弃并报错
+        if (cmd_overflow) {
+            cmd_len     = 0;
+            cmd_overflow = false;
+            Serial.println(F("# ERROR: command too long"));
+            continue;
+        }
+
+        // 处理完整命令行
         cmd_buf[cmd_len] = '\0';
         cmd_len = 0;
         if (cmd_buf[0] == '\0') continue;      // 空行跳过

--- a/simulator.py
+++ b/simulator.py
@@ -17,11 +17,9 @@ import time
 import sys
 import random
 
-# 导入增强版调参器组件（必须在配置之前，以便读取 config.json）
+# 导入增强版调参器组件
 try:
     import tuner as _tuner_mod
-
-    _tuner_mod.initialize_runtime_config(create_if_missing=True, verbose=True)
     from tuner import LLMTuner, AdvancedDataBuffer, TuningHistory, CONFIG
     from pid_safety import (
         apply_pid_guardrails,
@@ -34,6 +32,27 @@ try:
 except ImportError:
     print("[ERROR] 找不到 tuner.py，请确保文件存在")
     sys.exit(1)
+
+
+def ensure_runtime_config(
+    verbose: bool = False, create_if_missing: bool = True
+) -> None:
+    """
+    确保运行时配置已初始化。
+
+    默认情况下:
+    - create_if_missing=True: 若 config.json 不存在则创建默认配置;
+    - verbose=False: 避免被其他模块导入时产生多余的 stdout 输出。
+
+    该函数可安全地多次调用。
+    """
+    _tuner_mod.initialize_runtime_config(
+        create_if_missing=create_if_missing, verbose=verbose
+    )
+
+
+# 导入时静默初始化，供 benchmark 等调用方使用
+ensure_runtime_config(verbose=False)
 
 # ============================================================================
 # 配置（从 config.json / 环境变量读取，优先级：环境变量 > config.json > 默认值）
@@ -57,8 +76,6 @@ REQUIRED_STABLE_ROUNDS = CONFIG["REQUIRED_STABLE_ROUNDS"]
 
 SETPOINT     = 200.0  # 目标温度
 INITIAL_TEMP = 20.0   # 初始温度
-                      # 初始 PID
-kp, ki, kd = 1.0, 0.1, 0.05
 
 # ============================================================================
 # 仿真模型 (内置)
@@ -142,6 +159,7 @@ class HeatingSimulator:
 
 
 def run_simulation():
+    ensure_runtime_config(verbose=True)  # 直接运行时显示配置加载信息
     print("=" * 60)
     print("  LLM PID Tuner PRO - 仿真测试")
     print("=" * 60)

--- a/system_id.py
+++ b/system_id.py
@@ -61,7 +61,15 @@ def normalize_time_axis(time_data: List[float]) -> List[float]:
             if normalized[i] >= normalized[i - 1]
         ]
         avg_delta = sum(deltas) / len(deltas) if deltas else 0.0
+        # 检测时间单位是否可能为毫秒:
+        # 平均采样间隔大于 10
+        # 时间轴最大值大于 1000
+        is_milliseconds = False
         if avg_delta > 10.0:
+            is_milliseconds = True
+        elif max(normalized) > 1000.0:
+            is_milliseconds = True
+        if is_milliseconds:
             normalized = [value / 1000.0 for value in normalized]
 
     origin = normalized[0]

--- a/tuner.py
+++ b/tuner.py
@@ -24,6 +24,7 @@ import re
 import sys
 import os
 import math
+import traceback
 from collections import deque
 from typing import Optional, List, Dict, Any
 
@@ -366,7 +367,13 @@ class LLMTuner:
                 self.client = anthropic.Anthropic(
                     api_key=api_key, base_url=self.base_url
                 )
-        except (ImportError, Exception):
+        except ImportError:
+            # SDK 未安装或导入失败：回退到 requests
+            self.requests = self._import_requests()
+        except Exception:
+            # 其他初始化错误：调试模式下打印堆栈，然后回退
+            if self.debug_output:
+                traceback.print_exc()
             self.requests = self._import_requests()
         else:
             self.use_sdk = True


### PR DESCRIPTION
- simulator.py: remove module-level kp/ki/kd globals
- simulator.py: add a dedicate `ensure_runtime_config()` helper that callers can invoke explicitly
- tuner.py: catch `ImportError` seperately
- benchmark.py: explicitly call `initialize_runtime_config(verbose=False)` instead of relying on simulator import side effects
- system_id.py: reintroducing an additional heuristic `max(time_data) > 1000`
- firmware.cpp: add `cmd_overflow` flag and drop the entire command