### PR TITLE
docs: sync stable user docs from dev to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,12 +196,18 @@ timestamp_ms,setpoint,input,pwm,error,p,i,d
 {
   "MATLAB_MODEL_PATH": "C:/models/my_pid_model.slx",
   "MATLAB_PID_BLOCK_PATH": "my_pid_model/PID Controller",
-  "MATLAB_ROOT": "C:/Program Files/MATLAB/R2022b",
+  "MATLAB_ROOT": "D:/Program Files/MATLAB/R2025b",
   "MATLAB_OUTPUT_SIGNAL": "y_out",
   "MATLAB_SIM_STEP_TIME": 15.0,
   "MATLAB_SETPOINT": 200.0
 }
 ```
+
+上面这 6 项就是当前 `main` 分支下 **最小可用的 Simulink 配置**。
+
+- 如果只是第一次跑通，先填这 6 项即可
+- `MATLAB_ROOT` 里的版本号只是示例，请替换成你本机实际安装的 MATLAB 版本
+- 如果你已经知道准确块路径，优先使用显式的 `MATLAB_PID_BLOCK_PATH`
 
 ### 按场景看配置项
 
@@ -215,7 +221,7 @@ timestamp_ms,setpoint,input,pwm,error,p,i,d
 
 ### `MATLAB_ROOT` 什么时候要填
 
-- 用打包版 `exe` 跑 Simulink 时，建议直接填 `MATLAB_ROOT`，例如 `C:/Program Files/MATLAB/R2022b`
+- 用打包版 `exe` 跑 Simulink 时，建议直接填 `MATLAB_ROOT`，例如 `D:/Program Files/MATLAB/R2025b`
 - 源码方式运行时，如果你当前这个 Python 环境已经能正常 `import matlab.engine`，`MATLAB_ROOT` 可以留空
 - 如果源码运行也报 `No module named matlab.engine`，或者 MATLAB Engine 路径找不到，就把 `MATLAB_ROOT` 填上，同时按 [MATLAB/Simulink 调参指南](docs/zh-CN/MATLAB_GUIDE.md) 安装 Engine
 
@@ -466,7 +472,7 @@ python system_id.py --file sample_step.csv
 - 最新打包版请看 [Release](https://github.com/KINGSTON-115/llm-pid-tuner/releases/latest)
 - 打包方法见 [Issue #11](https://github.com/KINGSTON-115/llm-pid-tuner/issues/11)
 - 当前打包使用 Python `3.8`（见 `llm-pid-tuner.spec` 中 `matlabengineforpython3_8.pyd`）
-- MATLAB 测试环境：`R2022b`
+- 历史测试环境包含 `R2022b`；文档里的 `R2025b` 只是示例路径版本，请替换成你本机实际安装的 MATLAB 版本
 - 想看项目内部设计，请看 [PROJECT_DOC.md](docs/zh-CN/PROJECT_DOC.md)
 
 ## License

--- a/docs/en-US/MATLAB_GUIDE.md
+++ b/docs/en-US/MATLAB_GUIDE.md
@@ -2,28 +2,6 @@
 
 This guide explains how to use llm-pid-tuner to tune PID parameters on a MATLAB/Simulink simulation model with LLM assistance.
 
-If you plan to run from source, adapt the model integration yourself, or do targeted development work, use the `dev` branch instead of `main`.
-
----
-
-## Quick Start (download the exe, no Python required)
-
-If you don't want to set up a Python environment, just download the pre-built exe:
-
-1. Download the latest `llm-pid-tuner.exe` from the Releases page
-2. Place `llm-pid-tuner.exe` and `config.json` in the same folder
-3. Edit `config.json` — fill in your LLM API key and Simulink settings (see Step 3 below)
-4. Double-click `llm-pid-tuner.exe`, or run it from a terminal:
-   ```
-   llm-pid-tuner.exe
-   ```
-5. Select "Simulink simulation tuning" from the menu — the tool starts MATLAB automatically and begins tuning
-6. Press Enter to exit when tuning completes; results are saved back to the `.slx` file automatically
-
-> **Prerequisite:** MATLAB must be installed and licensed on your machine. The exe bundles the MATLAB Engine connector but still requires a local MATLAB installation.
-
----
-
 ## Quick Start (download the exe, no Python required)
 
 If you don't want to set up a Python environment, just download the pre-built exe:
@@ -78,9 +56,9 @@ cd <MATLAB_ROOT>/extern/engines/python
 python setup.py install
 ```
 
-Example path on Windows (replace with your MATLAB version):
+Example path on Windows (replace with the MATLAB version installed on your machine):
 ```
-D:\Program Files\MATLAB\R2022b\extern\engines\python
+D:\Program Files\MATLAB\R2025b\extern\engines\python
 ```
 
 Verify the install:
@@ -140,7 +118,7 @@ Add these fields alongside your existing LLM configuration:
 
   "MATLAB_MODEL_PATH"     : "C:/models/my_pid_model.slx",
   "MATLAB_PID_BLOCK_PATH" : "my_pid_model/PID Controller",
-  "MATLAB_ROOT"           : "C:/Program Files/MATLAB/R2022b",
+  "MATLAB_ROOT"           : "D:/Program Files/MATLAB/R2025b",
   "MATLAB_OUTPUT_SIGNAL"  : "y_out",
   "MATLAB_SIM_STEP_TIME"  : 10.0,
   "MATLAB_SETPOINT"       : 200.0
@@ -151,7 +129,7 @@ Add these fields alongside your existing LLM configuration:
 | :--- | :--- | :--- |
 | `MATLAB_MODEL_PATH` | Full path to the `.slx` file | `C:/models/my_model.slx` |
 | `MATLAB_PID_BLOCK_PATH` | Full block path inside the model | `my_model/PID Controller` |
-| `MATLAB_ROOT` | MATLAB installation root directory | `C:/Program Files/MATLAB/R2022b` |
+| `MATLAB_ROOT` | MATLAB installation root directory | `D:/Program Files/MATLAB/R2025b` |
 | `MATLAB_OUTPUT_SIGNAL` | To Workspace variable name | `y_out` |
 | `MATLAB_SIM_STEP_TIME` | Simulation time per tuning round (sim seconds) | `10.0` |
 | `MATLAB_SETPOINT` | Target value — must match the Setpoint in your model | `200.0` |

--- a/docs/en-US/README.md
+++ b/docs/en-US/README.md
@@ -169,12 +169,18 @@ If you prefer starting from a template, check `config.example.json`.
 {
   "MATLAB_MODEL_PATH": "C:/models/my_pid_model.slx",
   "MATLAB_PID_BLOCK_PATH": "my_pid_model/PID Controller",
-  "MATLAB_ROOT": "C:/Program Files/MATLAB/R2022b",
+  "MATLAB_ROOT": "D:/Program Files/MATLAB/R2025b",
   "MATLAB_OUTPUT_SIGNAL": "y_out",
   "MATLAB_SIM_STEP_TIME": 15.0,
   "MATLAB_SETPOINT": 200.0
 }
 ```
+
+Those six fields are the **minimum usable Simulink setup** on the current stable `main` branch.
+
+- If your goal is just to get the first run working, start with only those six
+- The MATLAB version in `MATLAB_ROOT` is only an example; replace it with the version installed on your machine
+- If you already know the exact controller block path, prefer the explicit `MATLAB_PID_BLOCK_PATH`
 
 ### Config groups by use case
 
@@ -188,7 +194,7 @@ If you prefer starting from a template, check `config.example.json`.
 
 ### When should I fill `MATLAB_ROOT`?
 
-- For the packaged `exe`, filling `MATLAB_ROOT` is recommended, for example `C:/Program Files/MATLAB/R2022b`
+- For the packaged `exe`, filling `MATLAB_ROOT` is recommended, for example `D:/Program Files/MATLAB/R2025b`
 - For source runs, you can leave it empty if the current Python environment already imports `matlab.engine` successfully
 - If source mode still fails with `No module named matlab.engine` or cannot locate the runtime, fill `MATLAB_ROOT` and follow the [MATLAB/Simulink Tuning Guide](docs/en-US/MATLAB_GUIDE.md)
 

--- a/docs/zh-CN/MATLAB_GUIDE.md
+++ b/docs/zh-CN/MATLAB_GUIDE.md
@@ -2,28 +2,6 @@
 
 本文档说明如何使用 llm-pid-tuner 对 MATLAB/Simulink 仿真模型进行 LLM 辅助 PID 调参。
 
-如果你打算源码运行、自己改模型适配逻辑，或做针对性开发，建议统一拉取 `dev` 分支代码，而不是直接使用 `main`。
-
----
-
-## 快速开始（下载 exe，零代码运行）
-
-如果你不想配置 Python 环境，直接下载打包好的 exe 即可：
-
-1. 从 Releases 页面下载最新的 `llm-pid-tuner.exe`
-2. 将 `llm-pid-tuner.exe` 和同目录的 `config.json` 放在同一个文件夹里
-3. 编辑 `config.json`，填入你的 LLM API Key 和 Simulink 相关配置（详见第 3 步）
-4. 双击运行 `llm-pid-tuner.exe`，或在终端中执行：
-   ```
-   llm-pid-tuner.exe
-   ```
-5. 在菜单中选择「Simulink 仿真调参」，程序会自动启动 MATLAB 并开始调参
-6. 调参完成后按 Enter 退出，结果已自动保存回 `.slx` 文件
-
-> **前提**：你的电脑上需要已安装并激活 MATLAB（exe 内置了 MATLAB Engine，但仍需要本机有 MATLAB 许可证）。
-
----
-
 ## 快速开始（下载 exe，零代码运行）
 
 如果你不想配置 Python 环境，直接下载打包好的 exe 即可：
@@ -76,9 +54,9 @@ cd <MATLAB_ROOT>/extern/engines/python
 python setup.py install
 ```
 
-Windows 示例路径（根据你的 MATLAB 版本替换）：
+Windows 示例路径（请替换成你本机 MATLAB 的实际版本）：
 ```
-D:\Program Files\MATLAB\R2022b\extern\engines\python
+D:\Program Files\MATLAB\R2025b\extern\engines\python
 ```
 
 安装完成后可以验证一下：
@@ -138,7 +116,7 @@ whos y_out   % 应该能看到 y_out 是 timeseries 类型
 
   "MATLAB_MODEL_PATH"     : "C:/models/my_pid_model.slx",
   "MATLAB_PID_BLOCK_PATH" : "my_pid_model/PID Controller",
-  "MATLAB_ROOT"           : "C:/Program Files/MATLAB/R2022b",
+  "MATLAB_ROOT"           : "D:/Program Files/MATLAB/R2025b",
   "MATLAB_OUTPUT_SIGNAL"  : "y_out",
   "MATLAB_SIM_STEP_TIME"  : 10.0,
   "MATLAB_SETPOINT"       : 200.0
@@ -149,7 +127,7 @@ whos y_out   % 应该能看到 y_out 是 timeseries 类型
 | :--- | :--- | :--- |
 | `MATLAB_MODEL_PATH` | Simulink `.slx` 文件完整路径 | `C:/models/my_model.slx` |
 | `MATLAB_PID_BLOCK_PATH` | PID 模块在模型中的完整路径 | `my_model/PID Controller` |
-| `MATLAB_ROOT` | MATLAB 安装根目录 | `C:/Program Files/MATLAB/R2022b` |
+| `MATLAB_ROOT` | MATLAB 安装根目录 | `D:/Program Files/MATLAB/R2025b` |
 | `MATLAB_OUTPUT_SIGNAL` | To Workspace 变量名 | `y_out` |
 | `MATLAB_SIM_STEP_TIME` | 每轮调参运行的仿真时长（仿真秒数） | `10.0` |
 | `MATLAB_SETPOINT` | 调参目标值，需与模型中 Setpoint 一致 | `200.0` |


### PR DESCRIPTION
## Summary\n- sync the safe user-facing documentation subset from dev to main\n- keep main docs aligned with the current stable main behavior\n- avoid bringing unreleased dev-only features into main docs\n\n## Scope\n- README.md\n- docs/en-US/README.md\n- docs/en-US/MATLAB_GUIDE.md\n- docs/zh-CN/MATLAB_GUIDE.md