### PR TITLE
fix: harden hardware pid apply flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ timestamp_ms,setpoint,input,pwm,error,p,i,d
 | Simulink | 只在 MATLAB/Simulink 模式下需要 | `MATLAB_MODEL_PATH` `MATLAB_PID_BLOCK_PATH` `MATLAB_ROOT` `MATLAB_OUTPUT_SIGNAL` `MATLAB_SIM_STEP_TIME` `MATLAB_SETPOINT`，以及按需填写 `MATLAB_CONTROL_SIGNAL` `MATLAB_SETPOINT_BLOCK` `MATLAB_PID_BLOCK_PATHS` `MATLAB_PID_BLOCK_PATH_2` `MATLAB_P/I/D_BLOCK_PATH(_2)` | 最小 6 项先跑通，复杂模型再逐步补充兼容字段 |
 | 代理 | 只有需要代理时才填 | `HTTP_PROXY` `HTTPS_PROXY` `ALL_PROXY` `NO_PROXY` | 留空就是不启用 |
 
+> 硬件模式还带有内建的采样保护阈值（采样超时与最少有效样本数）。这些属于固定安全策略，目前不作为 `config.json` 的用户配置项开放。
+
 ### `MATLAB_ROOT` 什么时候要填
 
 见 [MATLAB/Simulink 调参指南](docs/zh-CN/MATLAB_GUIDE.md)。

--- a/core/adapters.py
+++ b/core/adapters.py
@@ -135,16 +135,20 @@ class SimulinkEnv(BaseTuningEnvironment):
         pass # The simulator.py _run_tuning_loop does session.buffer.reset() which is now in engine
 
 class HardwareEnv(BaseTuningEnvironment):
+    # Fixed hardware safeguards. These stay out of user-facing config because
+    # most runs should share the same conservative serial sampling thresholds.
     SAMPLE_TIMEOUT_SEC = 20.0
     MIN_SAMPLES_PER_ROUND = 50
 
     def __init__(self, bridge: Any, initial_pid: Dict[str, float], controller: Any = None):
         self.bridge = bridge
-        self.current_pid = initial_pid
+        self.current_pid = dict(initial_pid)
+        self.current_secondary_pid: Optional[Dict[str, float]] = None
         self.controller = controller
         self.prompt_context = {}
         self.last_collect_issue = ""
         self.last_collect_warning = ""
+        self.last_apply_issue = ""
 
     def collect_samples(self) -> List[Dict[str, float]]:
         samples = []
@@ -194,6 +198,18 @@ class HardwareEnv(BaseTuningEnvironment):
             if line:
                 data = self.bridge.parse_data(line)
                 if data:
+                    if all(key in data for key in ("p", "i", "d")):
+                        self.current_pid = {
+                            "p": float(data["p"]),
+                            "i": float(data["i"]),
+                            "d": float(data["d"]),
+                        }
+                    if all(key in data for key in ("p2", "i2", "d2")):
+                        self.current_secondary_pid = {
+                            "p": float(data["p2"]),
+                            "i": float(data["i2"]),
+                            "d": float(data["d2"]),
+                        }
                     samples.append(data)
                     continue
                 invalid_lines += 1
@@ -201,15 +217,34 @@ class HardwareEnv(BaseTuningEnvironment):
         return samples
 
     def apply_pid(self, primary_pid: Dict[str, float], secondary_pid: Optional[Dict[str, float]] = None) -> None:
+        self.last_apply_issue = ""
         cmd = f"SET P:{primary_pid['p']} I:{primary_pid['i']} D:{primary_pid['d']}"
-        self.bridge.send_command(cmd)
-        self.current_pid = primary_pid
+        primary_sent = self.bridge.send_command(cmd)
+        if primary_sent is False:
+            self.last_apply_issue = (
+                f"Failed to apply hardware PID: {self.bridge.last_error or 'unknown write error'}"
+            )
+            return
+
+        self.current_pid = dict(primary_pid)
         if secondary_pid is not None:
             cmd2 = f"SET2 P:{secondary_pid['p']} I:{secondary_pid['i']} D:{secondary_pid['d']}"
-            self.bridge.send_command(cmd2)
+            secondary_sent = self.bridge.send_command(cmd2)
+            if secondary_sent is False:
+                self.last_apply_issue = (
+                    "Primary PID was applied, but controller 2 update failed: "
+                    f"{self.bridge.last_error or 'unknown write error'}"
+                )
+                return
+            self.current_secondary_pid = dict(secondary_pid)
 
     def get_current_pid(self) -> Tuple[Dict[str, float], Optional[Dict[str, float]]]:
-        return self.current_pid, None
+        secondary = (
+            dict(self.current_secondary_pid)
+            if self.current_secondary_pid is not None
+            else None
+        )
+        return dict(self.current_pid), secondary
 
     def get_setpoint(self) -> float:
         return 0.0 # Handled by hardware

--- a/core/csv_export.py
+++ b/core/csv_export.py
@@ -47,6 +47,7 @@ class CsvEventExporter:
             self._session_id = ""
             self._mode = ""
             self._round_index = 0
+            self._reset_round_tracking_unlocked()
 
     def handle_event(
         self, event_type: str, payload: Dict[str, Any], *, csv_path: str
@@ -58,6 +59,7 @@ class CsvEventExporter:
                 self._session_id = ""
                 self._mode = ""
                 self._round_index = 0
+                self._reset_round_tracking_unlocked()
                 return
 
             if event_type == "lifecycle":
@@ -135,6 +137,7 @@ class CsvEventExporter:
             return
         self._session_id = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
         self._round_index = 0
+        self._reset_round_tracking_unlocked()
         if force_new:
             self._mode = ""
 
@@ -172,6 +175,10 @@ class CsvEventExporter:
         self._handle = None
         self._writer = None
         self._path = None
+
+    def _reset_round_tracking_unlocked(self) -> None:
+        self._last_round_index = None
+        self._last_setpoint = None
 
     @staticmethod
     def _extract_round_index(detail: str) -> int | None:

--- a/core/tuning_engine.py
+++ b/core/tuning_engine.py
@@ -1,4 +1,5 @@
 import time
+from pathlib import Path
 from typing import Any, Dict, Optional
 from core.env import BaseTuningEnvironment
 from llm.client import LLMTuner
@@ -18,6 +19,7 @@ def _console(emit_console: bool, message: str, end: str = "\n") -> None:
         print(message, end=end, flush=True)
         # Also append to a log file
         try:
+            Path("logs").mkdir(parents=True, exist_ok=True)
             with open("logs/console_log.txt", "a", encoding="utf-8") as f:
                 f.write(message + end)
         except Exception:
@@ -162,6 +164,17 @@ def run_tuning_engine(
                 apply_rollback(session, evaluation.rollback_pid, rollback_secondary_pid=evaluation.rollback_secondary_pid)
                 publish_rollback(event_sink, round_index, evaluation, evaluation.rollback_pid, rollback_message)
                 env.apply_pid(evaluation.rollback_pid, evaluation.rollback_secondary_pid)
+                actual_primary, actual_secondary = env.get_current_pid()
+                session.buffer.current_pid = dict(actual_primary)
+                session.buffer.secondary_pid = (
+                    dict(actual_secondary) if actual_secondary is not None else None
+                )
+                rollback_apply_issue = str(getattr(env, "last_apply_issue", "") or "").strip()
+                if rollback_apply_issue:
+                    session.completed_reason = "error"
+                    _console(emit_console, f"\n[ERROR] {rollback_apply_issue}")
+                    _emit_lifecycle(event_sink, start_time, "error", rollback_apply_issue)
+                    break
                 _console(emit_console, f"[CMD] Applied rollback PID.")
                 continue
 
@@ -275,9 +288,23 @@ def run_tuning_engine(
                     _console(emit_console, f"[Guardrail] Controller 2: {'; '.join(sec_notes)}")
 
             env.apply_pid(safe_primary, safe_secondary)
+            actual_primary, actual_secondary = env.get_current_pid()
+            session.buffer.current_pid = dict(actual_primary)
+            session.buffer.secondary_pid = (
+                dict(actual_secondary) if actual_secondary is not None else None
+            )
+            apply_issue = str(getattr(env, "last_apply_issue", "") or "").strip()
+            if apply_issue:
+                session.completed_reason = "error"
+                _console(emit_console, f"\n[ERROR] {apply_issue}")
+                _emit_lifecycle(event_sink, start_time, "error", apply_issue)
+                break
             _console(emit_console, f"[CMD] Applied new PID parameters.")
             
-        if session.round_num >= CONFIG["MAX_TUNING_ROUNDS"]:
+        if (
+            session.round_num >= CONFIG["MAX_TUNING_ROUNDS"]
+            and session.completed_reason == "max_rounds_reached"
+        ):
             session.completed_reason = "max_rounds_reached"
             _console(emit_console, "\n[INFO] Reached maximum tuning rounds.")
             _emit_lifecycle(event_sink, start_time, "completed", "Reached maximum tuning rounds.")

--- a/docs/en-US/README.md
+++ b/docs/en-US/README.md
@@ -208,6 +208,8 @@ If your Simulink model is not the simplest "single standard PID Controller block
 | Simulink | MATLAB/Simulink mode only | `MATLAB_MODEL_PATH` `MATLAB_PID_BLOCK_PATH` `MATLAB_ROOT` `MATLAB_OUTPUT_SIGNAL` `MATLAB_SIM_STEP_TIME` `MATLAB_SETPOINT`, plus optional `MATLAB_CONTROL_SIGNAL` `MATLAB_SETPOINT_BLOCK` `MATLAB_PID_BLOCK_PATHS` `MATLAB_PID_BLOCK_PATH_2` `MATLAB_P/I/D_BLOCK_PATH(_2)` | Start with the minimum six fields, then add compatibility fields only when needed |
 | Proxy | Only if you need one | `HTTP_PROXY` `HTTPS_PROXY` `ALL_PROXY` `NO_PROXY` | Leave empty to disable |
 
+> Hardware mode also includes built-in sampling guardrails such as a serial sampling timeout and a minimum valid-sample threshold. These are fixed safety defaults and are not exposed as `config.json` user settings right now.
+
 ### When should I fill `MATLAB_ROOT`?
 
 See the [MATLAB/Simulink Tuning Guide](docs/en-US/MATLAB_GUIDE.md).

--- a/tests/test_csv_export.py
+++ b/tests/test_csv_export.py
@@ -96,3 +96,78 @@ class CsvExportTests(unittest.TestCase):
             self.assertEqual(rows[1]["i2"], "0.2")
             self.assertEqual(rows[1]["d2"], "0.02")
             self.assertTrue(rows[0]["session_id"])
+
+    def test_new_session_resets_round_and_setpoint_tracking(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            csv_path = Path(temp_dir) / "samples.csv"
+            config_patch = {"CSV_EXPORT_PATH": str(csv_path)}
+            with patch.dict(CONFIG, config_patch, clear=False):
+                publish_event(
+                    None,
+                    EVENT_LIFECYCLE,
+                    phase="starting",
+                    detail="Opening COM9 at 115200 baud.",
+                )
+                publish_event(
+                    None,
+                    EVENT_LIFECYCLE,
+                    phase="collecting",
+                    detail="Collecting data for round 1.",
+                )
+                publish_event(
+                    None,
+                    EVENT_SAMPLE,
+                    timestamp=1.0,
+                    setpoint=200.0,
+                    input=150.0,
+                    pwm=100.0,
+                    error=50.0,
+                    p=1.0,
+                    i=0.1,
+                    d=0.05,
+                )
+                publish_event(
+                    None,
+                    EVENT_LIFECYCLE,
+                    phase="completed",
+                    detail="Finished export.",
+                )
+                publish_event(
+                    None,
+                    EVENT_LIFECYCLE,
+                    phase="starting",
+                    detail="Opening COM9 at 115200 baud.",
+                )
+                publish_event(
+                    None,
+                    EVENT_LIFECYCLE,
+                    phase="collecting",
+                    detail="Collecting data for round 1.",
+                )
+                publish_event(
+                    None,
+                    EVENT_SAMPLE,
+                    timestamp=2.0,
+                    setpoint=200.0,
+                    input=151.0,
+                    pwm=101.0,
+                    error=49.0,
+                    p=1.0,
+                    i=0.1,
+                    d=0.05,
+                )
+                publish_event(
+                    None,
+                    EVENT_LIFECYCLE,
+                    phase="completed",
+                    detail="Finished export.",
+                )
+
+            with csv_path.open("r", encoding="utf-8", newline="") as handle:
+                rows = list(csv.DictReader(handle))
+
+            self.assertEqual(len(rows), 2)
+            self.assertEqual(rows[0]["round"], "1")
+            self.assertEqual(rows[1]["round"], "1")
+            self.assertEqual(rows[1]["setpoint"], "200.0")
+            self.assertTrue(rows[1]["session_id"])

--- a/tests/test_hardware_tui.py
+++ b/tests/test_hardware_tui.py
@@ -1,4 +1,5 @@
 import sys
+import time
 import unittest
 from pathlib import Path
 from queue import Queue
@@ -559,15 +560,15 @@ class HardwareTuiLoopTests(unittest.TestCase):
                     {
                         "BUFFER_SIZE": 3,
                         "MAX_TUNING_ROUNDS": 1,
-                        "HARDWARE_SAMPLE_TIMEOUT_SEC": 0.01,
                     },
                     clear=False,
                 ):
-                    result = tuner._run_hardware_tuning_loop(
-                        "COM9",
-                        event_sink=event_sink,
-                        emit_console=False,
-                    )
+                    with patch.object(tuner.HardwareEnv, "SAMPLE_TIMEOUT_SEC", 0.01):
+                        result = tuner._run_hardware_tuning_loop(
+                            "COM9",
+                            event_sink=event_sink,
+                            emit_console=False,
+                        )
 
         events = drain_event_queue(event_queue)
         self.assertEqual(result["completed_reason"], "error")
@@ -618,15 +619,15 @@ class HardwareTuiLoopTests(unittest.TestCase):
                     {
                         "BUFFER_SIZE": 3,
                         "MAX_TUNING_ROUNDS": 1,
-                        "HARDWARE_SAMPLE_TIMEOUT_SEC": 0.01,
                     },
                     clear=False,
                 ):
-                    result = tuner._run_hardware_tuning_loop(
-                        "COM9",
-                        event_sink=event_sink,
-                        emit_console=False,
-                    )
+                    with patch.object(tuner.HardwareEnv, "SAMPLE_TIMEOUT_SEC", 0.01):
+                        result = tuner._run_hardware_tuning_loop(
+                            "COM9",
+                            event_sink=event_sink,
+                            emit_console=False,
+                        )
 
         events = drain_event_queue(event_queue)
         self.assertEqual(result["completed_reason"], "error")
@@ -692,6 +693,113 @@ class HardwareTuiLoopTests(unittest.TestCase):
 
         self.assertEqual(result.get("completed_reason"), "error")
         self.assertIn("plain boom", str(result.get("error", "")))
+
+    def test_hardware_loop_reports_error_when_pid_apply_fails(self):
+        event_queue = Queue()
+        event_sink = QueueEventSink(event_queue)
+
+        class ApplyFailBridge:
+            def __init__(self, _port, _baudrate, emit_console=True):
+                self.serial_port = _port
+                self.emit_console = emit_console
+                self.last_error = ""
+                self._lines = iter(
+                    [
+                        _make_csv_line(0, 100.0),
+                        _make_csv_line(1, 120.0),
+                        _make_csv_line(2, 150.0),
+                    ]
+                )
+
+            def connect(self):
+                return True
+
+            def disconnect(self):
+                return None
+
+            def read_line(self):
+                line = next(self._lines, None)
+                if line is None:
+                    return ""
+                return line
+
+            def parse_data(self, line):
+                parts = line.split(",")
+                return {
+                    "timestamp": float(parts[0]),
+                    "setpoint": float(parts[1]),
+                    "input": float(parts[2]),
+                    "pwm": float(parts[3]),
+                    "error": float(parts[4]),
+                    "p": float(parts[5]),
+                    "i": float(parts[6]),
+                    "d": float(parts[7]),
+                }
+
+            def send_command(self, cmd):
+                if cmd == "STATUS":
+                    return True
+                self.last_error = "simulated write failure"
+                return False
+
+        class FakeTuner:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def analyze(self, *_args, **_kwargs):
+                return {
+                    "analysis_summary": "Apply a small change.",
+                    "tuning_action": "ADJUST_PID",
+                    "p": 1.2,
+                    "i": 0.1,
+                    "d": 0.05,
+                    "status": "TUNING",
+                }
+
+        with patch.object(tuner, "SerialBridge", ApplyFailBridge):
+            with patch.object(tuner, "LLMTuner", FakeTuner):
+                with patch.dict(
+                    tuner.CONFIG,
+                    {"BUFFER_SIZE": 3, "MAX_TUNING_ROUNDS": 1},
+                    clear=False,
+                ):
+                    result = tuner._run_hardware_tuning_loop(
+                        "COM9",
+                        event_sink=event_sink,
+                        emit_console=False,
+                    )
+
+        events = drain_event_queue(event_queue)
+        self.assertEqual(result["completed_reason"], "error")
+        self.assertEqual(result["final_pid"], {"p": 1.0, "i": 0.1, "d": 0.05})
+        self.assertTrue(
+            any(
+                "Failed to apply hardware PID" in str(event.get("detail", ""))
+                for event in events
+                if event.get("type") == EVENT_LIFECYCLE
+            )
+        )
+
+    def test_hardware_env_uses_fixed_sampling_thresholds(self):
+        class EmptyBridge:
+            def read_line(self):
+                return ""
+
+            def parse_data(self, _line):
+                return None
+
+        env = tuner.HardwareEnv(EmptyBridge(), {"p": 1.0, "i": 0.1, "d": 0.05})
+        self.assertEqual(env.SAMPLE_TIMEOUT_SEC, 20.0)
+        self.assertEqual(env.MIN_SAMPLES_PER_ROUND, 50)
+
+        start = time.time()
+        with patch.object(tuner.HardwareEnv, "SAMPLE_TIMEOUT_SEC", 0.0):
+            samples = env.collect_samples()
+        elapsed = time.time() - start
+
+        self.assertEqual(samples, [])
+        self.assertLess(elapsed, 0.5)
+        self.assertIn("No serial data was received", env.last_collect_issue)
 
     def test_main_pauses_on_error_result(self):
         with patch.object(


### PR DESCRIPTION
﻿## Summary
- stop hardware tuning when PID writes fail and keep reported PID aligned with the device state
- keep hardware sampling guardrails as fixed built-in defaults and document that policy
- reset CSV exporter round/setpoint tracking between sessions and ensure console log directory creation

## Validation
- `pytest -q`
- `cmd /c "echo.|build_with_matlab310.bat"`
