### PR TITLE
fix: add hardware pre-tuning dialog

### DIFF
--- a/core/tuning_engine.py
+++ b/core/tuning_engine.py
@@ -196,14 +196,18 @@ def run_tuning_engine(
             _emit_lifecycle(event_sink, start_time, "llm_request", f"Requesting PID for round {evaluation.round_index}.")
             
             if llm_mode == "generic" and hasattr(env, "bridge"):
-                from sim.prompt_context import build_hardware_prompt_context
+                from sim.prompt_context import (
+                    build_hardware_prompt_context,
+                    _merge_prompt_context,
+                )
                 bridge = env.bridge
                 # Determine secondary pid presence via buffer state
                 sec_pid = session.buffer.secondary_pid
-                prompt_context = build_hardware_prompt_context(
+                hardware_context = build_hardware_prompt_context(
                     getattr(bridge, "serial_port", "unknown"),
                     sec_pid
                 )
+                prompt_context = _merge_prompt_context(prompt_context, hardware_context)
                 
             if llm_mode == "simulink" and hasattr(env, "bridge"):
                 from sim.prompt_context import build_simulink_prompt_context

--- a/llm-pid-tuner.spec
+++ b/llm-pid-tuner.spec
@@ -8,7 +8,16 @@ conda_env = sys.prefix
 dll_path = os.path.join(conda_env, "Library", "bin")
 binaries = []
 if os.path.exists(dll_path):
-    for dll in ["ffi.dll", "ffi-7.dll", "ffi-8.dll", "libbz2.dll", "liblzma.dll"]:
+    for dll in [
+        "ffi.dll",
+        "ffi-7.dll",
+        "ffi-8.dll",
+        "libbz2.dll",
+        "liblzma.dll",
+        "libcrypto-3-x64.dll",
+        "libssl-3-x64.dll",
+        "libexpat.dll",
+    ]:
         dll_file = os.path.join(dll_path, dll)
         if os.path.exists(dll_file):
             binaries.append((dll_file, "."))

--- a/sim/pre_tuning_dialog.py
+++ b/sim/pre_tuning_dialog.py
@@ -27,6 +27,7 @@ _TEXT = {
         "input_prompt": "> ",
         "thinking": "[Guide] 正在整理你的偏好...",
         "summary": "[Guide] 已整理偏好：{summary}",
+        "llm_error": "[ERROR] 预调参对话需要大模型可用，但当前模型请求失败：{error}",
         "empty_skip": "[Guide] 未提供额外偏好，继续使用默认调参策略。",
         "fallback_summary": "用户要求：{user_text}",
         "priority_note": "显式用户偏好优先级高于默认调参启发式。",
@@ -40,11 +41,16 @@ _TEXT = {
         "input_prompt": "> ",
         "thinking": "[Guide] Summarizing your preferences...",
         "summary": "[Guide] Preference summary: {summary}",
+        "llm_error": "[ERROR] The pre-tuning conversation needs the configured LLM, but the model request failed: {error}",
         "empty_skip": "[Guide] No extra preference provided. Continuing with the default tuning strategy.",
         "fallback_summary": "User request: {user_text}",
         "priority_note": "Treat explicit user preferences as stronger constraints than the default tuning heuristic.",
     },
 }
+
+
+class PreTuningDialogError(RuntimeError):
+    """Raised when the pre-tuning LLM request cannot produce usable context."""
 
 
 def _can_prompt() -> bool:
@@ -180,22 +186,36 @@ def _build_prompt_context_from_result(
     return context
 
 
-def _summarize_user_request(language: str, user_text: str) -> Dict[str, Any] | None:
+def _summarize_user_request(language: str, user_text: str) -> Dict[str, Any]:
+    llm_messages: List[str] = []
+
+    def collect_llm_message(_label: str, message: str) -> None:
+        cleaned = str(message or "").strip()
+        if cleaned:
+            llm_messages.append(cleaned)
+
     tuner = LLMTuner(
         api_key=CONFIG["LLM_API_KEY"],
         base_url=CONFIG["LLM_API_BASE_URL"],
         model=CONFIG["LLM_MODEL_NAME"],
         provider=CONFIG["LLM_PROVIDER"],
         stream_callback=None,
-        log_callback=None,
+        log_callback=collect_llm_message,
         emit_console=False,
         timeout=CONFIG.get("LLM_REQUEST_TIMEOUT", 60),
         debug_output=CONFIG.get("LLM_DEBUG_OUTPUT", False),
     )
-    return tuner.request_json(
+    result = tuner.request_json(
         system_prompt=get_pre_tuning_dialog_system_prompt(language),
         user_prompt=build_pre_tuning_dialog_user_prompt(user_text, language),
     )
+    if result:
+        return result
+
+    detail = llm_messages[-1] if llm_messages else "empty or invalid LLM response"
+    provider = CONFIG.get("LLM_PROVIDER", "unknown")
+    model = CONFIG.get("LLM_MODEL_NAME", "unknown")
+    raise PreTuningDialogError(f"{detail} (provider={provider}, model={model})")
 
 
 def collect_pre_tuning_preferences(mode_label: str) -> Dict[str, Any] | None:
@@ -209,7 +229,22 @@ def collect_pre_tuning_preferences(mode_label: str) -> Dict[str, Any] | None:
         return None
 
     print(_text(language, "thinking"))
-    result = _summarize_user_request(language, user_text)
+    try:
+        result = _summarize_user_request(language, user_text)
+    except PreTuningDialogError as exc:
+        print(_text(language, "llm_error", error=str(exc)))
+        raise SystemExit(1) from exc
+
+    if not result:
+        print(
+            _text(
+                language,
+                "llm_error",
+                error="empty or invalid LLM response",
+            )
+        )
+        raise SystemExit(1)
+
     context = _build_prompt_context_from_result(
         language=language,
         user_text=user_text,
@@ -221,4 +256,5 @@ def collect_pre_tuning_preferences(mode_label: str) -> Dict[str, Any] | None:
 
 __all__ = [
     "collect_pre_tuning_preferences",
+    "PreTuningDialogError",
 ]

--- a/tests/test_hardware_tui.py
+++ b/tests/test_hardware_tui.py
@@ -147,6 +147,10 @@ class HardwareTuiLoopTests(unittest.TestCase):
         event_sink = QueueEventSink(event_queue)
         controller = SimulationController()
         sent_commands: list[str] = []
+        preference_context = {
+            "user_preference_summary": "Keep overshoot below 5%.",
+            "user_goal_priority": "low_overshoot",
+        }
         captured = {}
 
         class FakeBridge:
@@ -241,6 +245,7 @@ class HardwareTuiLoopTests(unittest.TestCase):
                         event_sink=event_sink,
                         controller=controller,
                         emit_console=False,
+                        prompt_context_overrides=preference_context,
                     )
 
         events = drain_event_queue(event_queue)
@@ -255,6 +260,14 @@ class HardwareTuiLoopTests(unittest.TestCase):
         self.assertTrue(any(cmd.startswith("SET P:") for cmd in sent_commands))
         self.assertEqual(captured["tuning_mode"], "generic")
         self.assertEqual(captured["prompt_context"]["serial_port"], "COM9")
+        self.assertEqual(
+            captured["prompt_context"]["user_preference_summary"],
+            preference_context["user_preference_summary"],
+        )
+        self.assertEqual(
+            captured["prompt_context"]["user_goal_priority"],
+            "low_overshoot",
+        )
 
     def test_hardware_loop_sends_set2_when_llm_returns_dual_controller_result(self):
         sent_commands: list[str] = []
@@ -678,6 +691,34 @@ class HardwareTuiLoopTests(unittest.TestCase):
         self.assertEqual(result, {"mode": "plain"})
         tui.assert_not_called()
         plain.assert_called_once_with("COM9", initial_pid=None)
+
+    def test_run_hardware_tuner_forwards_pre_tuning_preferences(self):
+        preference_context = {
+            "user_preference_summary": "Prioritize stability before speed.",
+            "user_goal_priority": "stability",
+        }
+        with patch.object(tuner, "initialize_runtime_config"):
+            with patch.object(tuner, "resolve_serial_port", return_value="COM9"):
+                with patch.object(tuner, "choose_hardware_ui_mode", return_value=False):
+                    with patch.object(
+                        tuner,
+                        "collect_pre_tuning_preferences",
+                        return_value=preference_context,
+                    ) as collect_preferences:
+                        with patch.object(
+                            tuner,
+                            "_run_hardware_tuning_plain",
+                            return_value={"mode": "plain"},
+                        ) as plain:
+                            result = tuner.run_hardware_tuner(force_plain=False)
+
+        self.assertEqual(result, {"mode": "plain"})
+        collect_preferences.assert_called_once_with("Hardware")
+        plain.assert_called_once_with(
+            "COM9",
+            initial_pid=None,
+            prompt_context_overrides=preference_context,
+        )
 
     def test_run_hardware_tuner_plain_failure_returns_error_result(self):
         with patch.object(tuner, "initialize_runtime_config"):

--- a/tests/test_pre_tuning_dialog.py
+++ b/tests/test_pre_tuning_dialog.py
@@ -9,7 +9,10 @@ from unittest.mock import patch
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from core.i18n import get_language, set_language
-from sim.pre_tuning_dialog import collect_pre_tuning_preferences
+from sim.pre_tuning_dialog import (
+    PreTuningDialogError,
+    collect_pre_tuning_preferences,
+)
 
 
 class PreTuningDialogTests(unittest.TestCase):
@@ -87,24 +90,37 @@ class PreTuningDialogTests(unittest.TestCase):
         self.assertEqual(context["user_soft_preferences"], ["Reach the target quickly"])
         self.assertEqual(get_language(), "en")
 
-    def test_collect_preferences_falls_back_to_raw_request_when_summary_fails(self):
+    def test_collect_preferences_exits_when_summary_fails(self):
         set_language("en")
         with patch("sim.pre_tuning_dialog._can_prompt", return_value=True):
             with patch("builtins.input", side_effect=["2", "Keep it stable first", "No oscillation", ""]):
                 with patch(
                     "sim.pre_tuning_dialog._summarize_user_request",
+                    side_effect=PreTuningDialogError("model unavailable"),
+                ):
+                    output = io.StringIO()
+                    with redirect_stdout(output):
+                        with self.assertRaises(SystemExit) as raised:
+                            collect_pre_tuning_preferences("Python Simulation")
+
+        self.assertEqual(raised.exception.code, 1)
+        self.assertIn("model unavailable", output.getvalue())
+
+    def test_collect_preferences_exits_when_summary_returns_empty_result(self):
+        set_language("en")
+        with patch("sim.pre_tuning_dialog._can_prompt", return_value=True):
+            with patch("builtins.input", side_effect=["2", "Keep it stable first", ""]):
+                with patch(
+                    "sim.pre_tuning_dialog._summarize_user_request",
                     return_value=None,
                 ):
-                    with redirect_stdout(io.StringIO()):
-                        context = collect_pre_tuning_preferences("Python Simulation")
+                    output = io.StringIO()
+                    with redirect_stdout(output):
+                        with self.assertRaises(SystemExit) as raised:
+                            collect_pre_tuning_preferences("Python Simulation")
 
-        self.assertIsNotNone(context)
-        assert context is not None
-        self.assertEqual(context["user_dialog_language"], "en")
-        self.assertEqual(context["user_goal_priority"], "balanced")
-        self.assertEqual(context["user_tuning_aggressiveness"], "normal")
-        self.assertIn("Keep it stable first", context["user_preference_summary"])
-        self.assertIn("No oscillation", context["user_preference_raw_request"])
+        self.assertEqual(raised.exception.code, 1)
+        self.assertIn("empty or invalid LLM response", output.getvalue())
 
 
 if __name__ == "__main__":

--- a/tuner.py
+++ b/tuner.py
@@ -24,7 +24,9 @@ from hw.bridge import SerialBridge, safe_pause, select_serial_port
 from llm.client import LLMTuner
 from core.tuning_engine import run_tuning_engine
 from core.adapters import HardwareEnv
-from sim.prompt_context import build_hardware_prompt_context
+from core.i18n import get_language
+from sim.pre_tuning_dialog import collect_pre_tuning_preferences
+from sim.prompt_context import build_hardware_prompt_context, _merge_prompt_context
 from sim.runtime import (
     QueueEventSink,
     SimulationController,
@@ -108,6 +110,7 @@ def _run_hardware_tuning_loop(
     controller: Optional[SimulationController] = None,
     emit_console: bool = True,
     initial_pid: Optional[Dict[str, float]] = None,
+    prompt_context_overrides: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     bridge = SerialBridge(serial_port, CONFIG["BAUD_RATE"], emit_console=False)
     start_time = time.time()
@@ -192,7 +195,10 @@ def _run_hardware_tuning_loop(
         )
 
         env = HardwareEnv(bridge, initial_pid or {"p": 0.0, "i": 0.0, "d": 0.0}, controller=controller)
-        env.prompt_context = build_hardware_prompt_context(serial_port, None)
+        env.prompt_context = _merge_prompt_context(
+            build_hardware_prompt_context(serial_port, None),
+            prompt_context_overrides,
+        )
 
         return run_tuning_engine(
             env=env,
@@ -232,6 +238,7 @@ def _run_hardware_tuning_loop(
 def _run_hardware_tuning_with_tui(
     serial_port: str,
     initial_pid: Optional[Dict[str, float]] = None,
+    prompt_context_overrides: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     from sim.tui import SimulationTUIApp
 
@@ -239,7 +246,7 @@ def _run_hardware_tuning_with_tui(
     controller = SimulationController()
     event_sink = QueueEventSink(event_queue)
     result_box: Dict[str, Any] = {}
-    language = choose_tui_language()
+    language = get_language()
 
     def make_worker(pid: Optional[Dict[str, float]]) -> Callable[[], None]:
         def worker() -> None:
@@ -249,6 +256,7 @@ def _run_hardware_tuning_with_tui(
                 controller=app.controller,
                 emit_console=False,
                 initial_pid=pid,
+                prompt_context_overrides=prompt_context_overrides,
             )
             result_box["result"] = result
             app._last_result = result
@@ -275,6 +283,7 @@ def _run_hardware_tuning_with_tui(
 def _run_hardware_tuning_plain(
     serial_port: str,
     initial_pid: Optional[Dict[str, float]] = None,
+    prompt_context_overrides: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     print("=" * 60)
     print("  LLM PID Tuner PRO - 增强版自动调参系统")
@@ -284,6 +293,7 @@ def _run_hardware_tuning_plain(
         serial_port,
         emit_console=True,
         initial_pid=initial_pid,
+        prompt_context_overrides=prompt_context_overrides,
     )
 
 
@@ -300,15 +310,20 @@ def run_hardware_tuner(
         return {"completed_reason": "no_serial_port"}
 
     use_tui = choose_hardware_ui_mode(force_plain)
+    prompt_context_overrides = collect_pre_tuning_preferences("Hardware")
+    runner_kwargs: Dict[str, Any] = {"initial_pid": initial_pid}
+    if prompt_context_overrides is not None:
+        runner_kwargs["prompt_context_overrides"] = prompt_context_overrides
+
     if use_tui:
         try:
-            return _run_hardware_tuning_with_tui(serial_port, initial_pid=initial_pid)
+            return _run_hardware_tuning_with_tui(serial_port, **runner_kwargs)
         except Exception as exc:
             print(f"[WARN] Failed to start the TUI ({exc}); falling back to plain output.")
             if bool(CONFIG.get("LLM_DEBUG_OUTPUT")):
                 traceback.print_exc()
     try:
-        return _run_hardware_tuning_plain(serial_port, initial_pid=initial_pid)
+        return _run_hardware_tuning_plain(serial_port, **runner_kwargs)
     except Exception as exc:
         print(f"[ERROR] Hardware tuning failed: {exc}")
         if bool(CONFIG.get("LLM_DEBUG_OUTPUT")):


### PR DESCRIPTION
## Summary
- show the pre-tuning conversation before hardware tuning starts
- preserve user preference context when hardware prompt context is refreshed each round
- include OpenSSL/expat DLLs from the matlab310 environment in the packaged exe

## Validation
- py -3.12 -m unittest tests.test_hardware_tui tests.test_pre_tuning_dialog
- py -3.12 -m unittest discover -s tests
- C:\Users\Administrator\conda-envs\matlab310\python.exe -m PyInstaller --clean --noconfirm llm-pid-tuner.spec
- dist\llm-pid-tuner.exe --help