### PR TITLE
fix: keep launcher open on pre-tuning failure

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -169,6 +169,15 @@ def main(argv: list[str] | None = None) -> None:
         except Exception:
             pass
         sys.exit(0)
+    except SystemExit as exc:
+        if exc.code not in (None, 0):
+            if isinstance(exc.code, str):
+                print(f"[ERROR] {exc.code}")
+            else:
+                print(f"[ERROR] Launcher exited with status {exc.code}.")
+            if can_prompt():
+                safe_pause("Press Enter to exit...")
+        raise
     except Exception as exc:
         print(f"[ERROR] Launcher failed: {exc}")
         if can_prompt():

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -77,6 +77,28 @@ class LauncherDispatchTests(unittest.TestCase):
         run_tuner.assert_called_once_with([])
         run_simulation.assert_not_called()
 
+    def test_main_pauses_on_nonzero_system_exit(self):
+        with patch.object(launcher, "initialize_runtime_config"):
+            with patch.object(launcher, "dispatch", side_effect=SystemExit(1)):
+                with patch.object(launcher, "can_prompt", return_value=True):
+                    with patch.object(launcher, "safe_pause") as pause:
+                        with self.assertRaises(SystemExit) as raised:
+                            launcher.main([])
+
+        self.assertEqual(raised.exception.code, 1)
+        pause.assert_called_once_with("Press Enter to exit...")
+
+    def test_main_does_not_pause_on_successful_system_exit(self):
+        with patch.object(launcher, "initialize_runtime_config"):
+            with patch.object(launcher, "dispatch", side_effect=SystemExit(0)):
+                with patch.object(launcher, "can_prompt", return_value=True):
+                    with patch.object(launcher, "safe_pause") as pause:
+                        with self.assertRaises(SystemExit) as raised:
+                            launcher.main([])
+
+        self.assertEqual(raised.exception.code, 0)
+        pause.assert_not_called()
+
 
 class TunerArgTests(unittest.TestCase):
     def test_cli_serial_port_wins_over_config_prompt(self):


### PR DESCRIPTION
## Summary
- pause the packaged launcher on non-zero SystemExit so pre-tuning LLM failures remain visible
- keep successful SystemExit paths such as --help unchanged
- add launcher regression coverage for non-zero and zero SystemExit behavior

## Validation
- C:\Users\Administrator\conda-envs\matlab310\python.exe -m unittest tests.test_launcher tests.test_pre_tuning_dialog tests.test_hardware_tui
- C:\Users\Administrator\conda-envs\matlab310\python.exe -m unittest discover -s tests