### PR TITLE
Add verified hardware profile adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ timestamp_ms,setpoint,input,pwm,error,p,i,d
 
 如果你不想自己适配协议，**最省事的办法就是直接从 `firmware.cpp` 开始。**
 
+如果你要对接本仓库里这三套已经验证过的工程，建议在 `config.json` 里明确指定 `HARDWARE_PROFILE`：
+
+- `generic_serial_csv`：默认 CSV 串口数据，适合 `firmware.cpp` 和演示模式
+- `stm32f407_openmv`：STM32F407 + OpenMV 瞄准链路，支持 `Status:` 文本、`T:x,y` 和 `N`
+- `mspm0_datavision`：MSPM0 DataVision 采样链路，当前按遥测优先处理，不默认写回参数
+
 ### 第 3 步：第一次运行 exe
 
 双击运行 `llm-pid-tuner.exe`。
@@ -116,6 +122,7 @@ timestamp_ms,setpoint,input,pwm,error,p,i,d
 {
   "SERIAL_PORT": "AUTO",
   "BAUD_RATE": 115200,
+  "HARDWARE_PROFILE": "generic_serial_csv",
   "LLM_API_KEY": "sk-your-key",
   "LLM_API_BASE_URL": "https://api.openai.com/v1",
   "LLM_MODEL_NAME": "gpt-4o",
@@ -198,6 +205,7 @@ timestamp_ms,setpoint,input,pwm,error,p,i,d
 {
   "SERIAL_PORT": "AUTO",
   "BAUD_RATE": 115200,
+  "HARDWARE_PROFILE": "generic_serial_csv",
   "LLM_API_KEY": "sk-your-key",
   "LLM_API_BASE_URL": "https://api.openai.com/v1",
   "LLM_MODEL_NAME": "gpt-4o",

--- a/config.example.json
+++ b/config.example.json
@@ -1,6 +1,7 @@
 {
     "SERIAL_PORT": "AUTO",
     "BAUD_RATE": 115200,
+    "HARDWARE_PROFILE": "generic_serial_csv",
     "LLM_API_KEY": "your-api-key-here",
     "LLM_API_BASE_URL": "https://api.openai.com/v1",
     "LLM_MODEL_NAME": "gpt-4o",

--- a/core/adapters.py
+++ b/core/adapters.py
@@ -2,6 +2,11 @@ import time
 from typing import Any, Dict, List, Optional, Tuple
 from core.env import BaseTuningEnvironment
 from core.config import CONFIG
+from hw.profiles import (
+    DEFAULT_HARDWARE_PROFILE,
+    get_hardware_sample_format_hint,
+    normalize_hardware_profile,
+)
 
 class PythonSimEnv(BaseTuningEnvironment):
     def __init__(self, sim: Any, setpoint: float, controller: Any = None):
@@ -166,6 +171,10 @@ class HardwareEnv(BaseTuningEnvironment):
         last_invalid_line = ""
         self.last_collect_issue = ""
         self.last_collect_warning = ""
+        hardware_profile = normalize_hardware_profile(
+            getattr(self.bridge, "hardware_profile", DEFAULT_HARDWARE_PROFILE)
+        )
+        expected_formats = get_hardware_sample_format_hint(hardware_profile)
 
         while len(samples) < target_size:
             if self.controller and hasattr(self.controller, "wait_while_paused") and not self.controller.wait_while_paused():
@@ -174,7 +183,6 @@ class HardwareEnv(BaseTuningEnvironment):
                 return samples
 
             if (time.time() - started_at) >= timeout_sec:
-                expected = "timestamp_ms,setpoint,input,pwm,error,p,i,d"
                 if len(samples) >= int(self.MIN_SAMPLES_PER_ROUND):
                     self.last_collect_warning = (
                         f"Hardware sampling timed out after {timeout_sec:.1f}s: "
@@ -192,7 +200,7 @@ class HardwareEnv(BaseTuningEnvironment):
                     detail = f" Last raw line: '{last_invalid_line[:160]}'." if last_invalid_line else ""
                     self.last_collect_issue = (
                         f"No valid hardware samples were parsed within {timeout_sec:.1f}s. "
-                        f"Expected CSV: {expected}.{detail}"
+                        f"Expected {expected_formats}.{detail}"
                     )
                 else:
                     self.last_collect_issue = (
@@ -225,6 +233,38 @@ class HardwareEnv(BaseTuningEnvironment):
 
     def apply_pid(self, primary_pid: Dict[str, float], secondary_pid: Optional[Dict[str, float]] = None) -> None:
         self.last_apply_issue = ""
+        hardware_profile = normalize_hardware_profile(
+            getattr(self.bridge, "hardware_profile", DEFAULT_HARDWARE_PROFILE)
+        )
+
+        if hardware_profile == "mspm0_datavision":
+            self.current_pid = dict(primary_pid)
+            if secondary_pid is not None:
+                self.current_secondary_pid = dict(secondary_pid)
+            return
+
+        if hasattr(self.bridge, "send_profile_command"):
+            primary_sent = self.bridge.send_profile_command("SET", primary_pid=primary_pid)
+            if primary_sent is False:
+                self.last_apply_issue = (
+                    f"Failed to apply hardware PID: {self.bridge.last_error or 'unknown write error'}"
+                )
+                return
+            self.current_pid = dict(primary_pid)
+            if secondary_pid is not None:
+                secondary_sent = self.bridge.send_profile_command(
+                    "SET2",
+                    secondary_pid=secondary_pid,
+                )
+                if secondary_sent is False:
+                    self.last_apply_issue = (
+                        "Primary PID was applied, but controller 2 update failed: "
+                        f"{self.bridge.last_error or 'unknown write error'}"
+                    )
+                    return
+                self.current_secondary_pid = dict(secondary_pid)
+            return
+
         cmd = f"SET P:{primary_pid['p']} I:{primary_pid['i']} D:{primary_pid['d']}"
         primary_sent = self.bridge.send_command(cmd)
         if primary_sent is False:

--- a/core/adapters.py
+++ b/core/adapters.py
@@ -238,9 +238,10 @@ class HardwareEnv(BaseTuningEnvironment):
         )
 
         if hardware_profile == "mspm0_datavision":
-            self.current_pid = dict(primary_pid)
-            if secondary_pid is not None:
-                self.current_secondary_pid = dict(secondary_pid)
+            self.last_apply_issue = (
+                "MSPM0 DataVision profile is read-only: PID write-back is disabled "
+                "until a command protocol is confirmed."
+            )
             return
 
         if hasattr(self.bridge, "send_profile_command"):

--- a/core/buffer.py
+++ b/core/buffer.py
@@ -122,11 +122,42 @@ class AdvancedDataBuffer:
         )
         lines.append("")
         lines.append(f"## 时间序列数据摘要 (采样 {len(sampled_data)} 点):")
-        lines.append("SimTime(ms), Input, PWM, Error")
+        dual_axis_keys = (
+            "target_x",
+            "target_y",
+            "offset_x",
+            "offset_y",
+            "servo_x",
+            "servo_y",
+        )
+        include_dual_axis = any(
+            any(key in d for key in dual_axis_keys) for d in sampled_data
+        )
+        if include_dual_axis:
+            lines.append(
+                "SimTime(ms), Input, PWM, Error, TargetX, TargetY, OffsetX, OffsetY, ServoX, ServoY"
+            )
+        else:
+            lines.append("SimTime(ms), Input, PWM, Error")
 
         for d in sampled_data:
-            lines.append(
-                f"{d.get('timestamp', 0):.0f}, {d.get('input', 0):.2f}, {d.get('pwm', 0):.1f}, {d.get('error', 0):.2f}"
+            base_values = (
+                f"{d.get('timestamp', 0):.0f}, "
+                f"{d.get('input', 0):.2f}, "
+                f"{d.get('pwm', 0):.1f}, "
+                f"{d.get('error', 0):.2f}"
             )
+            if include_dual_axis:
+                lines.append(
+                    f"{base_values}, "
+                    f"{d.get('target_x', '')}, "
+                    f"{d.get('target_y', '')}, "
+                    f"{d.get('offset_x', '')}, "
+                    f"{d.get('offset_y', '')}, "
+                    f"{d.get('servo_x', '')}, "
+                    f"{d.get('servo_y', '')}"
+                )
+            else:
+                lines.append(base_values)
 
         return "\n".join(lines)

--- a/core/config.py
+++ b/core/config.py
@@ -66,6 +66,7 @@ def ensure_utf8_console() -> None:
 DEFAULT_CONFIG: Dict[str, Any] = {
     "SERIAL_PORT"                   : "AUTO",
     "BAUD_RATE"                     : 115200,
+    "HARDWARE_PROFILE"              : "generic_serial_csv",
     "LLM_API_KEY"                   : "your-api-key-here",
     "LLM_API_BASE_URL"              : "https://api.openai.com/v1",
     "LLM_MODEL_NAME"                : "gpt-4o",

--- a/core/tuning_engine.py
+++ b/core/tuning_engine.py
@@ -226,12 +226,16 @@ def run_tuning_engine(
                     build_hardware_prompt_context,
                     _merge_prompt_context,
                 )
+                from hw.profiles import DEFAULT_HARDWARE_PROFILE, normalize_hardware_profile
                 bridge = env.bridge
                 # Determine secondary pid presence via buffer state
                 sec_pid = session.buffer.secondary_pid
                 hardware_context = build_hardware_prompt_context(
                     getattr(bridge, "serial_port", "unknown"),
-                    sec_pid
+                    sec_pid,
+                    hardware_profile=normalize_hardware_profile(
+                        getattr(bridge, "hardware_profile", DEFAULT_HARDWARE_PROFILE)
+                    ),
                 )
                 prompt_context = _merge_prompt_context(prompt_context, hardware_context)
                 

--- a/hw/bridge.py
+++ b/hw/bridge.py
@@ -6,11 +6,23 @@ hw/bridge.py - serial bridge helpers for real hardware and demo mode.
 
 from __future__ import annotations
 
+import math
 import re
+import struct
 import time
+from typing import Any, Dict, Optional
 
 import serial
 import serial.tools.list_ports
+
+from hw.profiles import (
+    DEFAULT_HARDWARE_PROFILE,
+    build_profile_commands,
+    get_hardware_board_family,
+    get_hardware_profile_info,
+    get_openmv_image_center,
+    normalize_hardware_profile,
+)
 
 
 DEMO_SERIAL_PORT = "COM_FAKE"
@@ -22,9 +34,49 @@ DEMO_SERIAL_PORT_ALIASES = {
     "VIRTUAL",
 }
 
+_DATAVISION_FRAME_HEADER = struct.pack("<I", 0x59485A53)
+_OPENMV_COMPACT_RE = re.compile(r"^T:(-?\d+),(-?\d+)$", re.IGNORECASE)
+_OPENMV_TARGET_RE = re.compile(
+    r"^TARGET:(-?\d+),(-?\d+),CENTER:(-?\d+),(-?\d+),OFFSET:(-?\d+),(-?\d+)$",
+    re.IGNORECASE,
+)
+_OPENMV_NO_TARGET_RE = re.compile(
+    r"^NO_TARGET(?:,CENTER:(-?\d+),(-?\d+))?$",
+    re.IGNORECASE,
+)
+_STM32_TARGET_RE = re.compile(r"^target\s*=\s*\(([-\d]+),\s*([-\d]+)\)$", re.IGNORECASE)
+_STM32_SERVO_RE = re.compile(r"^servo\.(x|y|delta)\s*=\s*([-\d]+(?:\.\d+)?)$", re.IGNORECASE)
+_STM32_PID_PAIR_RE = re.compile(
+    r"^pid\.(x|y)\s*=\s*([-\d]+(?:\.\d+)?)\s+([-\d]+(?:\.\d+)?)\s+([-\d]+(?:\.\d+)?)$",
+    re.IGNORECASE,
+)
+_STM32_PID_GAIN_RE = re.compile(
+    r"^pid\.(x|y)\.(kp|ki|kd)\s*=\s*([-\d]+(?:\.\d+)?)$",
+    re.IGNORECASE,
+)
+_STM32_RECT_RE = re.compile(r"^rect\.detect\s*=\s*(\d+)$", re.IGNORECASE)
+_STM32_IMU_RE = re.compile(
+    r"^imu\.(roll|pitch|yaw)\s*=\s*([-\d]+(?:\.\d+)?)$",
+    re.IGNORECASE,
+)
+
 
 def _is_demo_port(port: Optional[str]) -> bool:
     return str(port or "").strip().upper() in DEMO_SERIAL_PORT_ALIASES
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return float(default)
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return int(default)
 
 
 class _DemoSerialDevice:
@@ -107,6 +159,12 @@ class SerialBridge:
         self.serial = None
         self.emit_console = emit_console
         self.last_error = ""
+        self.hardware_profile = DEFAULT_HARDWARE_PROFILE
+        self._current_pid: Dict[str, float] = {"p": 1.0, "i": 0.1, "d": 0.05}
+        self._secondary_pid: Optional[Dict[str, float]] = None
+        self._sample_index = 0
+        self._datavision_buffer = bytearray()
+        self._datavision_pending: Dict[int, Dict[str, float]] = {}
 
     def connect(self) -> bool:
         try:
@@ -140,9 +198,55 @@ class SerialBridge:
             self.serial.close()
             self.serial = None
 
+    def _read_datavision_frame(self) -> Optional[bytes]:
+        if not self.serial or not self.serial.is_open:
+            return None
+
+        try:
+            waiting = int(getattr(self.serial, "in_waiting", 0) or 0)
+            chunk = self.serial.read(waiting or 1)
+        except Exception:
+            return None
+
+        if not chunk:
+            return None
+
+        self._datavision_buffer.extend(chunk)
+        return self._extract_datavision_frame()
+
+    def _extract_datavision_frame(self) -> Optional[bytes]:
+        header = _DATAVISION_FRAME_HEADER
+        buffer = self._datavision_buffer
+
+        header_index = buffer.find(header)
+        if header_index < 0:
+            if len(buffer) > len(header) - 1:
+                del buffer[: -(len(header) - 1)]
+            return None
+
+        if header_index > 0:
+            del buffer[:header_index]
+
+        if len(buffer) < 10:
+            return None
+
+        frame_len = int(struct.unpack_from("<I", buffer, 5)[0])
+        if frame_len < 11:
+            del buffer[:1]
+            return None
+
+        if len(buffer) < frame_len:
+            return None
+
+        frame = bytes(buffer[:frame_len])
+        del buffer[:frame_len]
+        return frame
+
     def read_line(self):
         if self.serial and self.serial.is_open:
             try:
+                if normalize_hardware_profile(self.hardware_profile) == "mspm0_datavision":
+                    return self._read_datavision_frame()
                 return self.serial.readline().decode("utf-8", errors="ignore").strip()
             except Exception:
                 pass
@@ -164,33 +268,409 @@ class SerialBridge:
         self.last_error = "serial port is not connected"
         return False
 
-    def parse_data(self, line: str):
-        if not line or line.startswith("#"):
-            return None
-        parts = line.split(",")
-        if len(parts) >= 5:
-            try:
-                return {
-                    "timestamp": float(parts[0]),
-                    "setpoint": float(parts[1]),
-                    "input": float(parts[2]),
-                    "pwm": float(parts[3]),
-                    "error": float(parts[4]),
-                    "p": float(parts[5]) if len(parts) > 5 else 1.0,
-                    "i": float(parts[6]) if len(parts) > 6 else 0.1,
-                    "d": float(parts[7]) if len(parts) > 7 else 0.05,
-                    **(
-                        {
-                            "p2": float(parts[8]),
-                            "i2": float(parts[9]),
-                            "d2": float(parts[10]),
-                        }
-                        if len(parts) > 10
-                        else {}
-                    ),
+    def send_profile_command(
+        self,
+        kind: str,
+        primary_pid: Optional[Dict[str, float]] = None,
+        secondary_pid: Optional[Dict[str, float]] = None,
+    ) -> bool:
+        commands = build_profile_commands(
+            self.hardware_profile,
+            kind,
+            primary_pid=primary_pid,
+            secondary_pid=secondary_pid,
+        )
+        if not commands:
+            self.last_error = (
+                f"{normalize_hardware_profile(self.hardware_profile)} does not expose {kind} commands"
+            )
+            return False
+
+        for cmd in commands:
+            if not self.send_command(cmd):
+                return False
+        return True
+
+    def _make_base_sample(self, sample_kind: str) -> Dict[str, Any]:
+        profile = normalize_hardware_profile(self.hardware_profile)
+        info = get_hardware_profile_info(profile)
+        sample: Dict[str, Any] = {
+            "hardware_profile": profile,
+            "board_family": info.get("board_family", "generic_serial"),
+            "sample_kind": sample_kind,
+            "timestamp": float(self._sample_index),
+            "setpoint": 0.0,
+            "input": 0.0,
+            "pwm": 0.0,
+            "error": 0.0,
+            "p": self._current_pid["p"],
+            "i": self._current_pid["i"],
+            "d": self._current_pid["d"],
+        }
+        if self._secondary_pid is not None:
+            sample.update(
+                {
+                    "p2": self._secondary_pid["p"],
+                    "i2": self._secondary_pid["i"],
+                    "d2": self._secondary_pid["d"],
                 }
-            except Exception:
-                pass
+            )
+        return sample
+
+    def _update_pid_cache(self, sample: Dict[str, Any]) -> None:
+        if all(key in sample for key in ("p", "i", "d")):
+            self._current_pid = {
+                "p": _safe_float(sample.get("p"), self._current_pid["p"]),
+                "i": _safe_float(sample.get("i"), self._current_pid["i"]),
+                "d": _safe_float(sample.get("d"), self._current_pid["d"]),
+            }
+        if all(key in sample for key in ("p2", "i2", "d2")):
+            self._secondary_pid = {
+                "p": _safe_float(sample.get("p2")),
+                "i": _safe_float(sample.get("i2")),
+                "d": _safe_float(sample.get("d2")),
+            }
+
+    def _parse_csv_sample(self, text: str) -> Optional[Dict[str, Any]]:
+        parts = [part.strip() for part in text.split(",")]
+        if len(parts) < 5:
+            return None
+
+        try:
+            sample = self._make_base_sample("csv")
+            sample.update(
+                {
+                    "timestamp": _safe_float(parts[0]),
+                    "setpoint": _safe_float(parts[1]),
+                    "input": _safe_float(parts[2]),
+                    "pwm": _safe_float(parts[3]),
+                    "error": _safe_float(parts[4]),
+                    "p": _safe_float(parts[5], sample["p"]) if len(parts) > 5 else sample["p"],
+                    "i": _safe_float(parts[6], sample["i"]) if len(parts) > 6 else sample["i"],
+                    "d": _safe_float(parts[7], sample["d"]) if len(parts) > 7 else sample["d"],
+                }
+            )
+            if len(parts) > 10:
+                sample.update(
+                    {
+                        "p2": _safe_float(parts[8]),
+                        "i2": _safe_float(parts[9]),
+                        "d2": _safe_float(parts[10]),
+                    }
+                )
+            self._sample_index += 1
+            self._update_pid_cache(sample)
+            return sample
+        except Exception:
+            return None
+
+    def _parse_openmv_sample(self, text: str) -> Optional[Dict[str, Any]]:
+        profile = normalize_hardware_profile(self.hardware_profile)
+        if profile != "stm32f407_openmv":
+            return None
+
+        center = get_openmv_image_center(profile) or (80, 60)
+        if text.upper() == "N":
+            sample = self._make_base_sample("openmv_no_target")
+            sample.update(
+                {
+                    "setpoint": 0.0,
+                    "input": 0.0,
+                    "pwm": 0.0,
+                    "error": 0.0,
+                    "image_center_x": center[0],
+                    "image_center_y": center[1],
+                    "has_target": False,
+                    "source_protocol": "openmv_no_target",
+                }
+            )
+            self._sample_index += 1
+            return sample
+
+        compact_match = _OPENMV_COMPACT_RE.match(text)
+        if compact_match:
+            target_x = int(compact_match.group(1))
+            target_y = int(compact_match.group(2))
+            offset_x = target_x - center[0]
+            offset_y = target_y - center[1]
+            error = math.hypot(offset_x, offset_y)
+            sample = self._make_base_sample("openmv_target")
+            sample.update(
+                {
+                    "setpoint": 0.0,
+                    "input": error,
+                    "error": error,
+                    "target_x": target_x,
+                    "target_y": target_y,
+                    "image_center_x": center[0],
+                    "image_center_y": center[1],
+                    "offset_x": offset_x,
+                    "offset_y": offset_y,
+                    "has_target": True,
+                    "source_protocol": "openmv_compact",
+                }
+            )
+            self._sample_index += 1
+            return sample
+
+        target_match = _OPENMV_TARGET_RE.match(text)
+        if target_match:
+            target_x = int(target_match.group(1))
+            target_y = int(target_match.group(2))
+            center_x = int(target_match.group(3))
+            center_y = int(target_match.group(4))
+            offset_x = int(target_match.group(5))
+            offset_y = int(target_match.group(6))
+            error = math.hypot(offset_x, offset_y)
+            sample = self._make_base_sample("openmv_target")
+            sample.update(
+                {
+                    "setpoint": 0.0,
+                    "input": error,
+                    "error": error,
+                    "target_x": target_x,
+                    "target_y": target_y,
+                    "image_center_x": center_x,
+                    "image_center_y": center_y,
+                    "offset_x": offset_x,
+                    "offset_y": offset_y,
+                    "has_target": True,
+                    "source_protocol": "openmv_expanded",
+                }
+            )
+            self._sample_index += 1
+            return sample
+
+        no_target_match = _OPENMV_NO_TARGET_RE.match(text)
+        if no_target_match:
+            sample = self._make_base_sample("openmv_no_target")
+            if no_target_match.group(1) and no_target_match.group(2):
+                sample["image_center_x"] = int(no_target_match.group(1))
+                sample["image_center_y"] = int(no_target_match.group(2))
+            else:
+                sample["image_center_x"] = center[0]
+                sample["image_center_y"] = center[1]
+            sample.update(
+                {
+                    "setpoint": 0.0,
+                    "input": 0.0,
+                    "pwm": 0.0,
+                    "error": 0.0,
+                    "has_target": False,
+                    "source_protocol": "openmv_no_target",
+                }
+            )
+            self._sample_index += 1
+            return sample
+
+        return None
+
+    def _finalize_stm32_snapshot(self, sample: Dict[str, Any]) -> Dict[str, Any]:
+        setpoint = sample.get("target_x")
+        input_value = sample.get("servo_x")
+        if setpoint is None and sample.get("target_y") is not None:
+            setpoint = sample.get("target_y")
+        if input_value is None and sample.get("servo_y") is not None:
+            input_value = sample.get("servo_y")
+
+        sample["setpoint"] = _safe_float(setpoint, sample.get("setpoint", 0.0))
+        sample["input"] = _safe_float(input_value, sample.get("input", 0.0))
+        sample["error"] = sample["setpoint"] - sample["input"]
+        sample["pwm"] = _safe_float(sample.get("servo_delta", sample.get("pwm", 0.0)))
+        sample.setdefault("source_protocol", "stm32_status")
+        return sample
+
+    def _parse_stm32_sample(self, text: str) -> Optional[Dict[str, Any]]:
+        profile = normalize_hardware_profile(self.hardware_profile)
+        if profile != "stm32f407_openmv":
+            return None
+
+        stripped = text.strip()
+        if not stripped or stripped.lower() in {"status:", "current config:"}:
+            return None
+
+        sample: Optional[Dict[str, Any]] = None
+
+        target_match = _STM32_TARGET_RE.match(stripped)
+        if target_match:
+            sample = sample or self._make_base_sample("status_snapshot")
+            sample["target_x"] = int(target_match.group(1))
+            sample["target_y"] = int(target_match.group(2))
+
+        servo_match = _STM32_SERVO_RE.match(stripped)
+        if servo_match:
+            sample = sample or self._make_base_sample("status_snapshot")
+            axis = servo_match.group(1).lower()
+            value = _safe_float(servo_match.group(2))
+            if axis == "x":
+                sample["servo_x"] = value
+            elif axis == "y":
+                sample["servo_y"] = value
+            else:
+                sample["servo_delta"] = value
+
+        pid_pair_match = _STM32_PID_PAIR_RE.match(stripped)
+        if pid_pair_match:
+            sample = sample or self._make_base_sample("status_snapshot")
+            axis = pid_pair_match.group(1).lower()
+            gains = {
+                "p": _safe_float(pid_pair_match.group(2)),
+                "i": _safe_float(pid_pair_match.group(3)),
+                "d": _safe_float(pid_pair_match.group(4)),
+            }
+            if axis == "x":
+                sample.update(gains)
+            else:
+                sample.update({"p2": gains["p"], "i2": gains["i"], "d2": gains["d"]})
+
+        pid_gain_match = _STM32_PID_GAIN_RE.match(stripped)
+        if pid_gain_match:
+            sample = sample or self._make_base_sample("status_snapshot")
+            axis = pid_gain_match.group(1).lower()
+            gain_name = pid_gain_match.group(2).lower()
+            value = _safe_float(pid_gain_match.group(3))
+            key_map = {"kp": "p", "ki": "i", "kd": "d"}
+            if axis == "x":
+                sample[key_map[gain_name]] = value
+            else:
+                sample[f"{key_map[gain_name]}2"] = value
+
+        rect_match = _STM32_RECT_RE.match(stripped)
+        if rect_match:
+            sample = sample or self._make_base_sample("status_snapshot")
+            sample["rect_detected"] = bool(int(rect_match.group(1)))
+
+        imu_match = _STM32_IMU_RE.match(stripped)
+        if imu_match:
+            sample = sample or self._make_base_sample("status_snapshot")
+            sample[f"imu_{imu_match.group(1).lower()}"] = _safe_float(imu_match.group(2))
+
+        if sample is None:
+            return None
+
+        sample["source_protocol"] = "stm32_status"
+        sample["sample_kind"] = "status_snapshot"
+        if "target_x" in sample or "servo_x" in sample or "target_y" in sample or "servo_y" in sample:
+            sample = self._finalize_stm32_snapshot(sample)
+        self._sample_index += 1
+        self._update_pid_cache(sample)
+        return sample
+
+    def _parse_multiline_text(self, text: str) -> Optional[Dict[str, Any]]:
+        combined: Dict[str, Any] = {}
+        found = False
+        for raw_line in text.replace("\r", "").split("\n"):
+            line = raw_line.strip()
+            if not line:
+                continue
+            part = self._parse_openmv_sample(line)
+            if part is None:
+                part = self._parse_stm32_sample(line)
+            if part is None:
+                part = self._parse_csv_sample(line)
+            if part is None:
+                continue
+            found = True
+            combined.update(part)
+
+        if not found:
+            return None
+
+        if combined.get("sample_kind") == "status_snapshot":
+            combined = self._finalize_stm32_snapshot(combined)
+        self._update_pid_cache(combined)
+        return combined
+
+    def _parse_datavision_frame(self, frame: bytes) -> Optional[Dict[str, Any]]:
+        if not frame or len(frame) < 15:
+            return None
+
+        if frame[:4] != _DATAVISION_FRAME_HEADER:
+            return None
+
+        frame_len = struct.unpack_from("<I", frame, 5)[0]
+        if len(frame) < frame_len or frame_len < 15:
+            return None
+
+        checksum = sum(frame[: frame_len - 1]) & 0xFF
+        if checksum != frame[frame_len - 1]:
+            return None
+
+        channel = int(frame[4])
+        cmd = int(frame[9])
+        payload = frame[10 : frame_len - 1]
+        if len(payload) < 4:
+            return None
+
+        value = struct.unpack_from("<f", payload)[0]
+        if cmd == 0x01:
+            self._datavision_pending[channel] = {"setpoint": float(value)}
+            return None
+
+        if cmd != 0x02:
+            return None
+
+        pending = self._datavision_pending.pop(channel, None)
+        setpoint = float(pending.get("setpoint", value)) if pending else float(value)
+        sample = self._make_base_sample("datavision_pair")
+        sample.update(
+            {
+                "timestamp": float(self._sample_index),
+                "setpoint": setpoint,
+                "input": float(value),
+                "error": float(setpoint - value),
+                "pwm": 0.0,
+                "channel": channel,
+                "source_protocol": "mspm0_datavision",
+                "cmd": cmd,
+            }
+        )
+        self._sample_index += 1
+        self._update_pid_cache(sample)
+        return sample
+
+    def parse_data(self, line: Any):
+        if line is None:
+            return None
+
+        profile = normalize_hardware_profile(self.hardware_profile)
+        if profile == "mspm0_datavision" and isinstance(line, (bytes, bytearray)):
+            return self._parse_datavision_frame(bytes(line))
+
+        if isinstance(line, (bytes, bytearray)):
+            line = bytes(line).decode("utf-8", errors="ignore")
+
+        text = str(line).strip()
+        if not text or text.startswith("#"):
+            return None
+
+        if "\n" in text or "\r" in text:
+            return self._parse_multiline_text(text)
+
+        if profile == "stm32f407_openmv":
+            parsed = self._parse_openmv_sample(text)
+            if parsed is not None:
+                self._update_pid_cache(parsed)
+                return parsed
+            parsed = self._parse_stm32_sample(text)
+            if parsed is not None:
+                return parsed
+
+        if profile == "mspm0_datavision":
+            parsed = self._parse_csv_sample(text)
+            if parsed is not None:
+                return parsed
+            return None
+
+        parsed = self._parse_csv_sample(text)
+        if parsed is not None:
+            return parsed
+        parsed = self._parse_openmv_sample(text)
+        if parsed is not None:
+            return parsed
+        parsed = self._parse_stm32_sample(text)
+        if parsed is not None:
+            return parsed
         return None
 
 

--- a/hw/bridge.py
+++ b/hw/bridge.py
@@ -35,6 +35,7 @@ DEMO_SERIAL_PORT_ALIASES = {
 }
 
 _DATAVISION_FRAME_HEADER = struct.pack("<I", 0x59485A53)
+_DATAVISION_MAX_FRAME_LEN = 128
 _OPENMV_COMPACT_RE = re.compile(r"^T:(-?\d+),(-?\d+)$", re.IGNORECASE)
 _OPENMV_TARGET_RE = re.compile(
     r"^TARGET:(-?\d+),(-?\d+),CENTER:(-?\d+),(-?\d+),OFFSET:(-?\d+),(-?\d+)$",
@@ -77,6 +78,16 @@ def _safe_int(value: Any, default: int = 0) -> int:
         return int(float(value))
     except (TypeError, ValueError):
         return int(default)
+
+
+def _parse_required_float(value: str) -> Optional[float]:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(parsed):
+        return None
+    return parsed
 
 
 class _DemoSerialDevice:
@@ -165,6 +176,7 @@ class SerialBridge:
         self._sample_index = 0
         self._datavision_buffer = bytearray()
         self._datavision_pending: Dict[int, Dict[str, float]] = {}
+        self._stm32_status_snapshot: Optional[Dict[str, Any]] = None
 
     def connect(self) -> bool:
         try:
@@ -231,7 +243,7 @@ class SerialBridge:
             return None
 
         frame_len = int(struct.unpack_from("<I", buffer, 5)[0])
-        if frame_len < 11:
+        if frame_len < 11 or frame_len > _DATAVISION_MAX_FRAME_LEN:
             del buffer[:1]
             return None
 
@@ -337,25 +349,39 @@ class SerialBridge:
             return None
 
         try:
+            values = [_parse_required_float(part) for part in parts[:5]]
+            if any(value is None for value in values):
+                return None
+
             sample = self._make_base_sample("csv")
             sample.update(
                 {
-                    "timestamp": _safe_float(parts[0]),
-                    "setpoint": _safe_float(parts[1]),
-                    "input": _safe_float(parts[2]),
-                    "pwm": _safe_float(parts[3]),
-                    "error": _safe_float(parts[4]),
-                    "p": _safe_float(parts[5], sample["p"]) if len(parts) > 5 else sample["p"],
-                    "i": _safe_float(parts[6], sample["i"]) if len(parts) > 6 else sample["i"],
-                    "d": _safe_float(parts[7], sample["d"]) if len(parts) > 7 else sample["d"],
+                    "timestamp": values[0],
+                    "setpoint": values[1],
+                    "input": values[2],
+                    "pwm": values[3],
+                    "error": values[4],
                 }
             )
+            for part_index, sample_key in ((5, "p"), (6, "i"), (7, "d")):
+                if len(parts) > part_index:
+                    value = _parse_required_float(parts[part_index])
+                    if value is None:
+                        return None
+                    sample[sample_key] = value
             if len(parts) > 10:
+                secondary_values = [
+                    _parse_required_float(parts[8]),
+                    _parse_required_float(parts[9]),
+                    _parse_required_float(parts[10]),
+                ]
+                if any(value is None for value in secondary_values):
+                    return None
                 sample.update(
                     {
-                        "p2": _safe_float(parts[8]),
-                        "i2": _safe_float(parts[9]),
-                        "d2": _safe_float(parts[10]),
+                        "p2": secondary_values[0],
+                        "i2": secondary_values[1],
+                        "d2": secondary_values[2],
                     }
                 )
             self._sample_index += 1
@@ -480,26 +506,46 @@ class SerialBridge:
         sample.setdefault("source_protocol", "stm32_status")
         return sample
 
+    def _merge_stm32_snapshot_line(self, sample: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        snapshot = self._stm32_status_snapshot
+        if snapshot is None:
+            snapshot = self._make_base_sample("status_snapshot")
+            self._stm32_status_snapshot = snapshot
+
+        snapshot.update(sample)
+        required_keys = {"target_x", "target_y", "servo_x", "servo_y", "servo_delta"}
+        if not required_keys.issubset(snapshot):
+            return None
+
+        complete = self._finalize_stm32_snapshot(dict(snapshot))
+        self._stm32_status_snapshot = None
+        self._sample_index += 1
+        self._update_pid_cache(complete)
+        return complete
+
     def _parse_stm32_sample(self, text: str) -> Optional[Dict[str, Any]]:
         profile = normalize_hardware_profile(self.hardware_profile)
         if profile != "stm32f407_openmv":
             return None
 
         stripped = text.strip()
-        if not stripped or stripped.lower() in {"status:", "current config:"}:
+        if not stripped:
+            return None
+        if stripped.lower() in {"status:", "current config:"}:
+            self._stm32_status_snapshot = self._make_base_sample("status_snapshot")
             return None
 
         sample: Optional[Dict[str, Any]] = None
 
         target_match = _STM32_TARGET_RE.match(stripped)
         if target_match:
-            sample = sample or self._make_base_sample("status_snapshot")
+            sample = sample or {}
             sample["target_x"] = int(target_match.group(1))
             sample["target_y"] = int(target_match.group(2))
 
         servo_match = _STM32_SERVO_RE.match(stripped)
         if servo_match:
-            sample = sample or self._make_base_sample("status_snapshot")
+            sample = sample or {}
             axis = servo_match.group(1).lower()
             value = _safe_float(servo_match.group(2))
             if axis == "x":
@@ -511,7 +557,7 @@ class SerialBridge:
 
         pid_pair_match = _STM32_PID_PAIR_RE.match(stripped)
         if pid_pair_match:
-            sample = sample or self._make_base_sample("status_snapshot")
+            sample = sample or {}
             axis = pid_pair_match.group(1).lower()
             gains = {
                 "p": _safe_float(pid_pair_match.group(2)),
@@ -525,7 +571,7 @@ class SerialBridge:
 
         pid_gain_match = _STM32_PID_GAIN_RE.match(stripped)
         if pid_gain_match:
-            sample = sample or self._make_base_sample("status_snapshot")
+            sample = sample or {}
             axis = pid_gain_match.group(1).lower()
             gain_name = pid_gain_match.group(2).lower()
             value = _safe_float(pid_gain_match.group(3))
@@ -537,12 +583,12 @@ class SerialBridge:
 
         rect_match = _STM32_RECT_RE.match(stripped)
         if rect_match:
-            sample = sample or self._make_base_sample("status_snapshot")
+            sample = sample or {}
             sample["rect_detected"] = bool(int(rect_match.group(1)))
 
         imu_match = _STM32_IMU_RE.match(stripped)
         if imu_match:
-            sample = sample or self._make_base_sample("status_snapshot")
+            sample = sample or {}
             sample[f"imu_{imu_match.group(1).lower()}"] = _safe_float(imu_match.group(2))
 
         if sample is None:
@@ -550,11 +596,7 @@ class SerialBridge:
 
         sample["source_protocol"] = "stm32_status"
         sample["sample_kind"] = "status_snapshot"
-        if "target_x" in sample or "servo_x" in sample or "target_y" in sample or "servo_y" in sample:
-            sample = self._finalize_stm32_snapshot(sample)
-        self._sample_index += 1
-        self._update_pid_cache(sample)
-        return sample
+        return self._merge_stm32_snapshot_line(sample)
 
     def _parse_multiline_text(self, text: str) -> Optional[Dict[str, Any]]:
         combined: Dict[str, Any] = {}

--- a/hw/profiles.py
+++ b/hw/profiles.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional
+
+DEFAULT_HARDWARE_PROFILE = "generic_serial_csv"
+
+_PROFILE_ALIASES = {
+    "generic": DEFAULT_HARDWARE_PROFILE,
+    "csv": DEFAULT_HARDWARE_PROFILE,
+    "firmware": DEFAULT_HARDWARE_PROFILE,
+    "default": DEFAULT_HARDWARE_PROFILE,
+    "stm32": "stm32f407_openmv",
+    "stm32f407": "stm32f407_openmv",
+    "openmv": "stm32f407_openmv",
+    "stm32f407_openmv": "stm32f407_openmv",
+    "mspm0": "mspm0_datavision",
+    "mspm03507": "mspm0_datavision",
+    "mspm0_datavision": "mspm0_datavision",
+}
+
+_PROFILE_INFO: Dict[str, Dict[str, Any]] = {
+    "generic_serial_csv": {
+        "board_family": "generic_serial",
+        "note": (
+            "Default CSV telemetry from firmware.cpp or similar demo firmware. "
+            "Expect timestamp,setpoint,input,pwm,error,p,i,d rows."
+        ),
+        "controller_count": 1,
+        "vision_center": None,
+    },
+    "stm32f407_openmv": {
+        "board_family": "stm32f407",
+        "note": (
+            "STM32F407 aiming console with OpenMV target stream. "
+            "Status snapshots expose target, servo, and pid.x/pid.y values; "
+            "treat this as a dual-controller profile."
+        ),
+        "controller_count": 2,
+        "vision_center": (80, 60),
+    },
+    "mspm0_datavision": {
+        "board_family": "mspm0",
+        "note": (
+            "MSPM0 DataVision telemetry is frame-based and telemetry-first. "
+            "Pair SEND_TARGET and SEND_FACT samples by channel, and keep "
+            "write-back disabled until a command protocol is confirmed."
+        ),
+        "controller_count": 1,
+        "vision_center": None,
+    },
+}
+
+
+def normalize_hardware_profile(profile: Any) -> str:
+    normalized = str(profile or "").strip().lower().replace("-", "_").replace(" ", "_")
+    if not normalized:
+        return DEFAULT_HARDWARE_PROFILE
+    return _PROFILE_ALIASES.get(normalized, normalized if normalized in _PROFILE_INFO else DEFAULT_HARDWARE_PROFILE)
+
+
+def get_hardware_profile_info(profile: Any) -> Dict[str, Any]:
+    normalized = normalize_hardware_profile(profile)
+    info = dict(_PROFILE_INFO.get(normalized, _PROFILE_INFO[DEFAULT_HARDWARE_PROFILE]))
+    info["hardware_profile"] = normalized
+    return info
+
+
+def get_hardware_board_family(profile: Any) -> str:
+    return str(get_hardware_profile_info(profile).get("board_family", "generic_serial"))
+
+
+def get_hardware_profile_note(profile: Any) -> str:
+    return str(get_hardware_profile_info(profile).get("note", ""))
+
+
+def is_dual_controller_profile(profile: Any) -> bool:
+    return int(get_hardware_profile_info(profile).get("controller_count", 1) or 1) > 1
+
+
+def get_openmv_image_center(profile: Any) -> Optional[tuple[int, int]]:
+    center = get_hardware_profile_info(profile).get("vision_center")
+    if not center:
+        return None
+    return int(center[0]), int(center[1])
+
+
+def get_hardware_sample_format_hint(profile: Any) -> str:
+    normalized = normalize_hardware_profile(profile)
+    if normalized == "stm32f407_openmv":
+        return "STM32 Status: lines plus OpenMV T:x,y / N messages"
+    if normalized == "mspm0_datavision":
+        return "MSPM0 DataVision binary frames"
+    return "CSV rows: timestamp,setpoint,input,pwm,error,p,i,d"
+
+
+def build_profile_commands(
+    profile: Any,
+    kind: str,
+    primary_pid: Optional[Dict[str, float]] = None,
+    secondary_pid: Optional[Dict[str, float]] = None,
+) -> List[str]:
+    normalized = normalize_hardware_profile(profile)
+    command_kind = str(kind or "").strip().upper()
+    primary_pid = primary_pid or {}
+    secondary_pid = secondary_pid or {}
+
+    if command_kind == "STATUS":
+        return ["status"] if normalized == "stm32f407_openmv" else ["STATUS"]
+
+    if command_kind not in {"SET", "SET2"}:
+        return []
+
+    if normalized == "mspm0_datavision":
+        return []
+
+    pid = primary_pid if command_kind == "SET" else secondary_pid
+    if not pid:
+        return []
+
+    if normalized == "stm32f407_openmv":
+        prefix = "pid.x" if command_kind == "SET" else "pid.y"
+        return [
+            f"config {prefix}.kp {pid.get('p', 0.0)}",
+            f"config {prefix}.ki {pid.get('i', 0.0)}",
+            f"config {prefix}.kd {pid.get('d', 0.0)}",
+        ]
+
+    gain_label = "P" if command_kind == "SET" else "P"
+    return [
+        f"{command_kind} {gain_label}:{pid.get('p', 0.0)} I:{pid.get('i', 0.0)} D:{pid.get('d', 0.0)}"
+    ]

--- a/sim/prompt_context.py
+++ b/sim/prompt_context.py
@@ -2,22 +2,39 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
+from hw.profiles import (
+    DEFAULT_HARDWARE_PROFILE,
+    get_hardware_board_family,
+    get_hardware_profile_note,
+    is_dual_controller_profile,
+    normalize_hardware_profile,
+)
+
 def build_hardware_prompt_context(
     serial_port: str,
     secondary_pid: Optional[Dict[str, float]] = None,
+    *,
+    hardware_profile: str = DEFAULT_HARDWARE_PROFILE,
 ) -> Dict[str, Any]:
+    normalized_profile = normalize_hardware_profile(hardware_profile)
+    dual_controller = is_dual_controller_profile(normalized_profile)
     context = {
         "source": "serial_hardware",
         "serial_port": serial_port,
+        "hardware_profile": normalized_profile,
+        "board_family": get_hardware_board_family(normalized_profile),
+        "hardware_profile_note": get_hardware_profile_note(normalized_profile),
         "controller_output_signal": "PWM",
         "pwm_signal_available": True,
         "tuning_style": "conservative_hardware_safe",
         "per_round_guardrail_hint": "Keep P within about 3x the current value, and keep I/D within about 4x. Prefer smaller moves near stability.",
     }
-    if secondary_pid is not None:
-        context["controller_count"] = 2
+    controller_count = 2 if dual_controller or secondary_pid is not None else 1
+    context["controller_count"] = controller_count
+    if controller_count > 1:
         context["controller_structure"] = "dual_controller"
         context["controller_2_label"] = "controller_2"
+    if secondary_pid is not None:
         context["controller_2_pid"] = dict(secondary_pid)
     return context
 

--- a/tests/test_hardware_tui.py
+++ b/tests/test_hardware_tui.py
@@ -259,7 +259,11 @@ class HardwareTuiLoopTests(unittest.TestCase):
             with patch.object(tuner, "LLMTuner", FakeTuner):
                 with patch.dict(
                     tuner.CONFIG,
-                    {"BUFFER_SIZE": 3, "MAX_TUNING_ROUNDS": 1},
+                    {
+                        "BUFFER_SIZE": 3,
+                        "MAX_TUNING_ROUNDS": 1,
+                        "HARDWARE_PROFILE": "stm32f407_openmv",
+                    },
                     clear=False,
                 ):
                     result = tuner._run_hardware_tuning_loop(
@@ -290,6 +294,12 @@ class HardwareTuiLoopTests(unittest.TestCase):
             captured["prompt_context"]["user_goal_priority"],
             "low_overshoot",
         )
+        self.assertEqual(
+            captured["prompt_context"]["hardware_profile"],
+            "stm32f407_openmv",
+        )
+        self.assertEqual(captured["prompt_context"]["board_family"], "stm32f407")
+        self.assertEqual(captured["prompt_context"]["controller_count"], 2)
 
     def test_hardware_loop_sends_set2_when_llm_returns_dual_controller_result(self):
         sent_commands: list[str] = []

--- a/tests/test_hardware_tui.py
+++ b/tests/test_hardware_tui.py
@@ -793,6 +793,29 @@ class HardwareTuiLoopTests(unittest.TestCase):
             )
         )
 
+    def test_mspm0_apply_pid_reports_read_only_without_changing_cached_pid(self):
+        class Mspm0Bridge:
+            hardware_profile = "mspm0_datavision"
+            last_error = ""
+
+            def send_profile_command(self, *_args, **_kwargs):
+                raise AssertionError("MSPM0 telemetry-only profile must not write PID")
+
+            def disconnect(self):
+                return None
+
+        env = tuner.HardwareEnv(
+            Mspm0Bridge(),
+            {"p": 1.0, "i": 0.1, "d": 0.05},
+        )
+
+        env.apply_pid({"p": 2.0, "i": 0.2, "d": 0.1})
+        current_pid, secondary_pid = env.get_current_pid()
+
+        self.assertEqual(current_pid, {"p": 1.0, "i": 0.1, "d": 0.05})
+        self.assertIsNone(secondary_pid)
+        self.assertIn("read-only", env.last_apply_issue)
+
     def test_hardware_env_uses_fixed_sampling_thresholds(self):
         class EmptyBridge:
             def read_line(self):

--- a/tests/test_hw_bridge.py
+++ b/tests/test_hw_bridge.py
@@ -1,6 +1,7 @@
 import sys
 import types
 import unittest
+import struct
 from pathlib import Path
 from unittest.mock import patch
 
@@ -8,6 +9,21 @@ from unittest.mock import patch
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from hw.bridge import DEMO_SERIAL_PORT, SerialBridge, select_serial_port
+
+
+def _make_datavision_frame(cmd: int, channel: int, value: float) -> bytes:
+    head = struct.pack("<I", 0x59485A53)
+    payload = struct.pack("<f", value)
+    frame_len = 11 + len(payload)
+    frame = (
+        head
+        + struct.pack("<B", channel)
+        + struct.pack("<I", frame_len)
+        + struct.pack("<B", cmd)
+        + payload
+    )
+    checksum = sum(frame) & 0xFF
+    return frame + struct.pack("<B", checksum)
 
 
 class DemoSerialBridgeTests(unittest.TestCase):
@@ -43,6 +59,113 @@ class DemoSerialBridgeTests(unittest.TestCase):
         self.assertAlmostEqual(data["p2"], 3.5, places=3)
         self.assertAlmostEqual(data["i2"], 0.7, places=3)
         self.assertAlmostEqual(data["d2"], 0.2, places=3)
+
+    def test_stm32_status_snapshot_is_normalized(self):
+        bridge = SerialBridge(DEMO_SERIAL_PORT, 115200, emit_console=False)
+        bridge.hardware_profile = "stm32f407_openmv"
+
+        data = bridge.parse_data(
+            "Status:\r\n"
+            "  pid.x = 0.310 0.110 0.000\r\n"
+            "  pid.y = 0.280 0.110 0.000\r\n"
+            "  target = (123,456)\r\n"
+            "  servo.x = 750\r\n"
+            "  servo.y = 480\r\n"
+            "  servo.delta = 6\r\n"
+        )
+
+        self.assertIsNotNone(data)
+        self.assertEqual(data["hardware_profile"], "stm32f407_openmv")
+        self.assertEqual(data["board_family"], "stm32f407")
+        self.assertEqual(data["sample_kind"], "status_snapshot")
+        self.assertAlmostEqual(data["p"], 0.31, places=3)
+        self.assertAlmostEqual(data["i"], 0.11, places=3)
+        self.assertAlmostEqual(data["d"], 0.0, places=3)
+        self.assertAlmostEqual(data["p2"], 0.28, places=3)
+        self.assertAlmostEqual(data["i2"], 0.11, places=3)
+        self.assertAlmostEqual(data["d2"], 0.0, places=3)
+        self.assertAlmostEqual(data["setpoint"], 123.0, places=3)
+        self.assertAlmostEqual(data["input"], 750.0, places=3)
+        self.assertAlmostEqual(data["error"], -627.0, places=3)
+        self.assertEqual(data["target_y"], 456)
+        self.assertEqual(data["servo_y"], 480)
+        self.assertEqual(data["pwm"], 6.0)
+
+    def test_openmv_target_messages_are_normalized(self):
+        bridge = SerialBridge(DEMO_SERIAL_PORT, 115200, emit_console=False)
+        bridge.hardware_profile = "stm32f407_openmv"
+
+        target_data = bridge.parse_data("T:123,456\n")
+        no_target_data = bridge.parse_data("N\n")
+
+        self.assertIsNotNone(target_data)
+        self.assertEqual(target_data["sample_kind"], "openmv_target")
+        self.assertTrue(target_data["has_target"])
+        self.assertEqual(target_data["target_x"], 123)
+        self.assertEqual(target_data["target_y"], 456)
+        self.assertEqual(target_data["image_center_x"], 80)
+        self.assertEqual(target_data["image_center_y"], 60)
+        self.assertGreater(target_data["error"], 0.0)
+
+        self.assertIsNotNone(no_target_data)
+        self.assertEqual(no_target_data["sample_kind"], "openmv_no_target")
+        self.assertFalse(no_target_data["has_target"])
+        self.assertEqual(no_target_data["error"], 0.0)
+        self.assertEqual(no_target_data["image_center_x"], 80)
+        self.assertEqual(no_target_data["image_center_y"], 60)
+
+    def test_mspm0_datavision_frames_are_pair_normalized(self):
+        bridge = SerialBridge(DEMO_SERIAL_PORT, 115200, emit_console=False)
+        bridge.hardware_profile = "mspm0_datavision"
+
+        target_frame = _make_datavision_frame(0x01, 0x01, 1500.0)
+        fact_frame = _make_datavision_frame(0x02, 0x01, 1450.0)
+
+        self.assertIsNone(bridge.parse_data(target_frame))
+        data = bridge.parse_data(fact_frame)
+
+        self.assertIsNotNone(data)
+        self.assertEqual(data["hardware_profile"], "mspm0_datavision")
+        self.assertEqual(data["sample_kind"], "datavision_pair")
+        self.assertEqual(data["channel"], 1)
+        self.assertAlmostEqual(data["setpoint"], 1500.0, places=3)
+        self.assertAlmostEqual(data["input"], 1450.0, places=3)
+        self.assertAlmostEqual(data["error"], 50.0, places=3)
+
+    def test_stm32_profile_commands_emit_config_syntax(self):
+        bridge = SerialBridge(DEMO_SERIAL_PORT, 115200, emit_console=False)
+        bridge.hardware_profile = "stm32f407_openmv"
+        sent_commands: list[str] = []
+        bridge.send_command = lambda cmd: sent_commands.append(cmd) or True  # type: ignore[method-assign]
+
+        ok = bridge.send_profile_command(
+            "SET",
+            primary_pid={"p": 0.31, "i": 0.11, "d": 0.0},
+        )
+
+        self.assertTrue(ok)
+        self.assertEqual(
+            sent_commands,
+            [
+                "config pid.x.kp 0.31",
+                "config pid.x.ki 0.11",
+                "config pid.x.kd 0.0",
+            ],
+        )
+
+    def test_mspm0_profile_blocks_writeback_commands(self):
+        bridge = SerialBridge(DEMO_SERIAL_PORT, 115200, emit_console=False)
+        bridge.hardware_profile = "mspm0_datavision"
+        sent_commands: list[str] = []
+        bridge.send_command = lambda cmd: sent_commands.append(cmd) or True  # type: ignore[method-assign]
+
+        ok = bridge.send_profile_command(
+            "SET",
+            primary_pid={"p": 1.0, "i": 0.1, "d": 0.05},
+        )
+
+        self.assertFalse(ok)
+        self.assertEqual(sent_commands, [])
 
 
 class SelectSerialPortTests(unittest.TestCase):

--- a/tests/test_hw_bridge.py
+++ b/tests/test_hw_bridge.py
@@ -91,6 +91,34 @@ class DemoSerialBridgeTests(unittest.TestCase):
         self.assertEqual(data["servo_y"], 480)
         self.assertEqual(data["pwm"], 6.0)
 
+    def test_stm32_status_snapshot_accumulates_line_by_line(self):
+        bridge = SerialBridge(DEMO_SERIAL_PORT, 115200, emit_console=False)
+        bridge.hardware_profile = "stm32f407_openmv"
+
+        lines = [
+            "Status:",
+            "pid.x = 0.310 0.110 0.000",
+            "pid.y = 0.280 0.110 0.000",
+            "target = (123,456)",
+            "servo.x = 750",
+            "servo.y = 480",
+            "servo.delta = 6",
+        ]
+
+        partial = [bridge.parse_data(line) for line in lines[:-1]]
+        data = bridge.parse_data(lines[-1])
+
+        self.assertEqual(partial, [None, None, None, None, None, None])
+        self.assertIsNotNone(data)
+        self.assertEqual(data["sample_kind"], "status_snapshot")
+        self.assertAlmostEqual(data["p"], 0.31, places=3)
+        self.assertAlmostEqual(data["p2"], 0.28, places=3)
+        self.assertAlmostEqual(data["setpoint"], 123.0, places=3)
+        self.assertAlmostEqual(data["input"], 750.0, places=3)
+        self.assertEqual(data["target_y"], 456)
+        self.assertEqual(data["servo_y"], 480)
+        self.assertEqual(data["pwm"], 6.0)
+
     def test_openmv_target_messages_are_normalized(self):
         bridge = SerialBridge(DEMO_SERIAL_PORT, 115200, emit_console=False)
         bridge.hardware_profile = "stm32f407_openmv"
@@ -131,6 +159,51 @@ class DemoSerialBridgeTests(unittest.TestCase):
         self.assertAlmostEqual(data["setpoint"], 1500.0, places=3)
         self.assertAlmostEqual(data["input"], 1450.0, places=3)
         self.assertAlmostEqual(data["error"], 50.0, places=3)
+
+    def test_datavision_oversized_frame_is_dropped_and_resyncs(self):
+        bridge = SerialBridge(DEMO_SERIAL_PORT, 115200, emit_console=False)
+        valid_frame = _make_datavision_frame(0x02, 0x01, 1450.0)
+        oversized_frame = (
+            struct.pack("<I", 0x59485A53)
+            + b"\x01"
+            + struct.pack("<I", 129)
+            + b"\x02"
+            + b"\x00\x00\x00\x00"
+        )
+        bridge._datavision_buffer.extend(oversized_frame + valid_frame)
+
+        self.assertIsNone(bridge._extract_datavision_frame())
+        self.assertEqual(bridge._extract_datavision_frame(), valid_frame)
+
+    def test_csv_rejects_invalid_required_numeric_fields(self):
+        bridge = SerialBridge(DEMO_SERIAL_PORT, 115200, emit_console=False)
+
+        for index in range(5):
+            fields = ["1", "100", "90", "40", "10"]
+            fields[index] = "not-a-number"
+
+            with self.subTest(field=index):
+                self.assertIsNone(bridge.parse_data(",".join(fields)))
+
+    def test_csv_rejects_invalid_present_optional_pid_fields(self):
+        bridge = SerialBridge(DEMO_SERIAL_PORT, 115200, emit_console=False)
+
+        for index in range(5, 11):
+            fields = ["1", "100", "90", "40", "10", "1.0", "0.1", "0.05", "2.0", "0.2", "0.1"]
+            fields[index] = "not-a-number"
+
+            with self.subTest(field=index):
+                self.assertIsNone(bridge.parse_data(",".join(fields)))
+
+    def test_csv_preserves_defaults_for_missing_optional_pid_fields(self):
+        bridge = SerialBridge(DEMO_SERIAL_PORT, 115200, emit_console=False)
+
+        data = bridge.parse_data("1,100,90,40,10")
+
+        self.assertIsNotNone(data)
+        self.assertAlmostEqual(data["p"], 1.0, places=3)
+        self.assertAlmostEqual(data["i"], 0.1, places=3)
+        self.assertAlmostEqual(data["d"], 0.05, places=3)
 
     def test_stm32_profile_commands_emit_config_syntax(self):
         bridge = SerialBridge(DEMO_SERIAL_PORT, 115200, emit_console=False)

--- a/tests/test_prompt_context.py
+++ b/tests/test_prompt_context.py
@@ -8,6 +8,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from sim.prompt_context import (
     _first_nonempty_text,
+    build_hardware_prompt_context,
     build_python_sim_prompt_context,
     build_simulink_prompt_context,
     default_prompt_context_for_mode,
@@ -38,6 +39,32 @@ class BuildPythonSimContextTests(unittest.TestCase):
         self.assertEqual(ctx["source"], "built_in_python_heating_simulator")
         self.assertTrue(ctx["pwm_signal_available"])
         self.assertIn("per_round_guardrail_hint", ctx)
+
+
+class BuildHardwareContextTests(unittest.TestCase):
+    def test_stm32_profile_sets_board_family_and_dual_controller_note(self):
+        ctx = build_hardware_prompt_context(
+            "COM9",
+            None,
+            hardware_profile="stm32f407_openmv",
+        )
+
+        self.assertEqual(ctx["hardware_profile"], "stm32f407_openmv")
+        self.assertEqual(ctx["board_family"], "stm32f407")
+        self.assertEqual(ctx["controller_count"], 2)
+        self.assertIn("OpenMV", ctx["hardware_profile_note"])
+        self.assertIn("dual", ctx["hardware_profile_note"])
+
+    def test_mspm0_profile_marks_telemetry_first_note(self):
+        ctx = build_hardware_prompt_context(
+            "COM8",
+            None,
+            hardware_profile="mspm0_datavision",
+        )
+
+        self.assertEqual(ctx["hardware_profile"], "mspm0_datavision")
+        self.assertEqual(ctx["board_family"], "mspm0")
+        self.assertIn("telemetry", ctx["hardware_profile_note"])
 
 
 class BuildSimulinkContextTests(unittest.TestCase):

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -31,6 +31,7 @@ class ConfigLoadTests(unittest.TestCase):
         required_keys = [
             "SERIAL_PORT",
             "BAUD_RATE",
+            "HARDWARE_PROFILE",
             "LLM_API_KEY",
             "LLM_API_BASE_URL",
             "LLM_MODEL_NAME",
@@ -335,6 +336,25 @@ class PromptSelectionTests(unittest.TestCase):
         self.assertIn("controller_1、controller_2、status", prompt)
         self.assertNotIn("tuning_action、p、i、d、status", prompt)
         self.assertIn("双控制器调参策略", prompt)
+
+    def test_hardware_user_prompt_carries_profile_metadata(self):
+        prompt = build_user_prompt(
+            "## Current Status\n- Current PID: P=1.0, I=0.1, D=0.05",
+            "No tuning history yet.",
+            tuning_mode="hardware",
+            prompt_context={
+                "serial_port": "COM9",
+                "hardware_profile": "stm32f407_openmv",
+                "board_family": "stm32f407",
+                "hardware_profile_note": "STM32F407 status console with OpenMV target stream.",
+                "controller_count": 2,
+            },
+        )
+
+        self.assertIn("hardware profile: stm32f407_openmv", prompt)
+        self.assertIn("board family: stm32f407", prompt)
+        self.assertIn("OpenMV target stream", prompt)
+        self.assertIn("controller_1、controller_2、status", prompt)
 
     def test_simulink_user_prompt_uses_consistent_five_percent_target(self):
         prompt = build_user_prompt(

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -667,6 +667,35 @@ class BufferTests(unittest.TestCase):
         self.assertIn("0.4", text)
         self.assertIn("0.08", text)
 
+    def test_to_prompt_data_includes_dual_axis_hardware_fields_when_present(self):
+        buf = AdvancedDataBuffer(max_size=5)
+        buf.add(
+            {
+                "timestamp": 1,
+                "setpoint": 123.0,
+                "input": 750.0,
+                "pwm": 6.0,
+                "error": -627.0,
+                "target_x": 123,
+                "target_y": 456,
+                "offset_x": 43,
+                "offset_y": 396,
+                "servo_x": 750.0,
+                "servo_y": 480.0,
+            }
+        )
+
+        text = buf.to_prompt_data()
+
+        self.assertIn("TargetX", text)
+        self.assertIn("TargetY", text)
+        self.assertIn("OffsetX", text)
+        self.assertIn("OffsetY", text)
+        self.assertIn("ServoX", text)
+        self.assertIn("ServoY", text)
+        self.assertIn("123", text)
+        self.assertIn("456", text)
+
 
 class SimulatorStepTests(unittest.TestCase):
     def test_constants_reasonable(self):

--- a/tests/test_simulator_tui.py
+++ b/tests/test_simulator_tui.py
@@ -37,6 +37,12 @@ from sim.runtime import (
 DEFAULT_DOCTOR_CHECKS = [DoctorCheck("api", "PASS", "ok")]
 
 
+def static_text(widget) -> str:
+    if hasattr(widget, "content"):
+        return str(widget.content)
+    return str(widget.renderable)
+
+
 class QueueEventSinkTests(unittest.TestCase):
     def test_collects_expected_event_shapes(self):
         event_queue = Queue()
@@ -1318,7 +1324,7 @@ class TextualDashboardTests(unittest.IsolatedAsyncioTestCase):
             await pilot.press("p")
             await pilot.press("r")
 
-            help_text = str(app.query_one("#help", Static).content)
+            help_text = static_text(app.query_one("#help", Static))
             self.assertTrue(app.state.paused)
             self.assertEqual(len(app.state.event_history), 0)
             self.assertEqual(app.state.latest_action, "-")
@@ -1361,7 +1367,7 @@ class TextualDashboardTests(unittest.IsolatedAsyncioTestCase):
             app._poll_events()
 
             status = app.query_one("#status", Static)
-            self.assertIn("C2", str(status.content))
+            self.assertIn("C2", static_text(status))
 
     async def test_reset_view_ignores_queued_pre_reset_events(self):
         from sim.tui import SimulationTUIApp
@@ -1479,7 +1485,7 @@ class TextualDashboardTests(unittest.IsolatedAsyncioTestCase):
                     break
                 await pilot.pause()
 
-            help_text = str(app.query_one("#help", Static).content)
+            help_text = static_text(app.query_one("#help", Static))
             self.assertTrue(controller.should_stop)
             self.assertTrue(worker_finished.is_set())
             self.assertIn("s", help_text)
@@ -1554,7 +1560,7 @@ class TextualDashboardTests(unittest.IsolatedAsyncioTestCase):
                     break
                 await pilot.pause()
 
-            help_text = str(app.query_one("#help", Static).content)
+            help_text = static_text(app.query_one("#help", Static))
             self.assertTrue(worker_started.is_set())
             self.assertEqual(
                 next_round_calls,

--- a/tuner.py
+++ b/tuner.py
@@ -20,6 +20,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from core.config import CONFIG, initialize_runtime_config
 from hw.bridge import SerialBridge, safe_pause, select_serial_port
+from hw.profiles import DEFAULT_HARDWARE_PROFILE, normalize_hardware_profile
 from llm.client import LLMTuner
 from core.tuning_engine import run_tuning_engine
 from core.adapters import HardwareEnv
@@ -92,6 +93,9 @@ def _run_hardware_tuning_loop(
     prompt_context_overrides: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     bridge = SerialBridge(serial_port, CONFIG["BAUD_RATE"], emit_console=False)
+    bridge.hardware_profile = normalize_hardware_profile(
+        CONFIG.get("HARDWARE_PROFILE", DEFAULT_HARDWARE_PROFILE)
+    )
     start_time = time.time()
     current_stream_round = [0]
     llm_log_callback, llm_stream_callback = make_llm_tuner_callbacks(
@@ -145,7 +149,10 @@ def _run_hardware_tuning_loop(
 
     try:
         _console(emit_console, "[CMD] Sending: STATUS")
-        status_sent = bridge.send_command("STATUS")
+        if hasattr(bridge, "send_profile_command"):
+            status_sent = bridge.send_profile_command("STATUS")
+        else:
+            status_sent = bridge.send_command("STATUS")
         _emit_log(event_sink, start_time, "cmd", "STATUS")
         if status_sent is False:
             warn = f"[WARN] STATUS send failed: {bridge.last_error or 'unknown write error'}"
@@ -155,14 +162,20 @@ def _run_hardware_tuning_loop(
             _console(emit_console, "[CMD] Sent: STATUS")
         if initial_pid:
             cmd = f"SET P:{initial_pid['p']} I:{initial_pid['i']} D:{initial_pid['d']}"
-            cmd_sent = bridge.send_command(cmd)
-            _emit_log(event_sink, start_time, "cmd", cmd)
-            if cmd_sent is False:
-                warn = f"[WARN] Initial PID send failed: {bridge.last_error or 'unknown write error'}"
-                _console(emit_console, warn)
-                _emit_log(event_sink, start_time, "warn", warn)
+            if normalize_hardware_profile(getattr(bridge, "hardware_profile", DEFAULT_HARDWARE_PROFILE)) == "mspm0_datavision":
+                _console(emit_console, "[INFO] MSPM0 telemetry-only profile; skipping initial PID write-back.")
             else:
-                _console(emit_console, f"[CMD] Initial PID: {cmd}")
+                if hasattr(bridge, "send_profile_command"):
+                    cmd_sent = bridge.send_profile_command("SET", primary_pid=initial_pid)
+                else:
+                    cmd_sent = bridge.send_command(cmd)
+                _emit_log(event_sink, start_time, "cmd", cmd)
+                if cmd_sent is False:
+                    warn = f"[WARN] Initial PID send failed: {bridge.last_error or 'unknown write error'}"
+                    _console(emit_console, warn)
+                    _emit_log(event_sink, start_time, "warn", warn)
+                else:
+                    _console(emit_console, f"[CMD] Initial PID: {cmd}")
         time.sleep(1)
 
         _console(emit_console, "[INFO] 开始采集数据...")
@@ -175,7 +188,11 @@ def _run_hardware_tuning_loop(
 
         env = HardwareEnv(bridge, initial_pid or {"p": 0.0, "i": 0.0, "d": 0.0}, controller=controller)
         env.prompt_context = _merge_prompt_context(
-            build_hardware_prompt_context(serial_port, None),
+            build_hardware_prompt_context(
+                serial_port,
+                None,
+                hardware_profile=getattr(bridge, "hardware_profile", DEFAULT_HARDWARE_PROFILE),
+            ),
             prompt_context_overrides,
         )
 


### PR DESCRIPTION
## Summary
- Add explicit hardware profiles for generic CSV, STM32F407 + OpenMV, and MSPM0 DataVision telemetry.
- Normalize verified firmware data formats into the existing tuner sample schema, including STM32 `Status:` snapshots, OpenMV `T:x,y` / `N`, and MSPM0 DataVision binary frames.
- Thread profile metadata through config, tuning prompts, hardware adapters, and README guidance while leaving the validated firmware trees unchanged.

## Test Plan
- `python -m unittest tests.test_hw_bridge -v`
- `python -m unittest tests.test_prompt_context -v`
- `python -m unittest tests.test_hardware_tui -v`
- `python -m unittest tests.test_regression -v`
- `python -m unittest tests.test_simulator_tui -v`
- `python -m unittest discover -s tests -v` (`316` tests)

## Notes
- Hardware-in-loop validation was not run because no board is currently attached; coverage uses samples and protocol facts from the validated firmware folders.
- MSPM0 DataVision is telemetry-first and intentionally blocks PID write-back until a command protocol is confirmed.