### PR TITLE
docs: document hardware profile options

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ timestamp_ms,setpoint,input,pwm,error,p,i,d
 
 如果你不想自己适配协议，**最省事的办法就是直接从 `firmware.cpp` 开始。**
 
-如果你要对接本仓库里这三套已经验证过的工程，建议在 `config.json` 里明确指定 `HARDWARE_PROFILE`：
+如果你要对接这些已知协议格式，可以在 `config.json` 里明确指定 `HARDWARE_PROFILE`：
 
 - `generic_serial_csv`：默认 CSV 串口数据，适合 `firmware.cpp` 和演示模式
 - `stm32f407_openmv`：STM32F407 + OpenMV 瞄准链路，支持 `Status:` 文本、`T:x,y` 和 `N`
-- `mspm0_datavision`：MSPM0 DataVision 采样链路，当前按遥测优先处理，不默认写回参数
+- `mspm0_datavision`：MSPM0 DataVision 采样链路，当前是只读遥测模式，不向硬件写回 PID 参数
 
 ### 第 3 步：第一次运行 exe
 
@@ -252,7 +252,7 @@ timestamp_ms,setpoint,input,pwm,error,p,i,d
 
 | 分类 | 什么时候需要 | 字段 | 说明 |
 | :--- | :--- | :--- | :--- |
-| 硬件串口 | 真实硬件调参 | `SERIAL_PORT` `BAUD_RATE` | `SERIAL_PORT` 不确定先填 `AUTO`，`BAUD_RATE` 要和固件一致 |
+| 硬件串口 | 真实硬件调参 | `SERIAL_PORT` `BAUD_RATE` `HARDWARE_PROFILE` | `SERIAL_PORT` 不确定先填 `AUTO`，`BAUD_RATE` 要和固件一致；普通 CSV 固件保持 `HARDWARE_PROFILE=generic_serial_csv` |
 | LLM 基础 | 所有模式都需要 | `LLM_API_KEY` `LLM_API_BASE_URL` `LLM_MODEL_NAME` `LLM_PROVIDER` | 这是最核心的一组配置，不填就无法调参 |
 | 调参行为 | 想微调策略时再改 | `BUFFER_SIZE` `MIN_ERROR_THRESHOLD` `MAX_TUNING_ROUNDS` `LLM_REQUEST_TIMEOUT` `LLM_DEBUG_OUTPUT` `PID_MAX_INCREASE_RATIO` `GOOD_ENOUGH_AVG_ERROR` `GOOD_ENOUGH_STEADY_STATE_ERROR` `GOOD_ENOUGH_OVERSHOOT` `REQUIRED_STABLE_ROUNDS` | 新手建议先保持默认，只有在采样不够、网络慢或需要排查日志时再动。`PID_MAX_INCREASE_RATIO` 用于限制单次参数调整的最大倍数；`GOOD_ENOUGH_*` 定义“已经够好”的阈值；`REQUIRED_STABLE_ROUNDS` 是连续稳定轮数，默认 3 轮。 |
 | Simulink | 只在 MATLAB/Simulink 模式下需要 | `MATLAB_MODEL_PATH` `MATLAB_PID_BLOCK_PATH` `MATLAB_ROOT` `MATLAB_OUTPUT_SIGNAL` `MATLAB_SIM_STEP_TIME` `MATLAB_SETPOINT`，以及按需填写 `MATLAB_CONTROL_SIGNAL` `MATLAB_SETPOINT_BLOCK` `MATLAB_PID_BLOCK_PATHS` `MATLAB_PID_BLOCK_PATH_2` `MATLAB_P/I/D_BLOCK_PATH(_2)` | 最小 6 项先跑通，复杂模型再逐步补充兼容字段 |

--- a/docs/en-US/PROJECT_DOC.md
+++ b/docs/en-US/PROJECT_DOC.md
@@ -169,6 +169,14 @@ Field descriptions:
 
 If your hardware protocol differs, the recommended approach is to align your firmware with `firmware.cpp` rather than patching the host-side code.
 
+Hardware mode can also select a built-in protocol adapter through `HARDWARE_PROFILE`:
+
+- `generic_serial_csv`: the default profile, using the CSV protocol above.
+- `stm32f407_openmv`: STM32F407 + OpenMV text telemetry, including `Status:` snapshots, `T:x,y`, and `N`.
+- `mspm0_datavision`: MSPM0 DataVision binary telemetry frames. This profile is read-only for now and does not send PID values back to hardware until a write-back protocol is confirmed.
+
+If you do not need a special hardware protocol, keep `HARDWARE_PROFILE=generic_serial_csv`; the existing workflow stays unchanged.
+
 ## 6. Key Design Principles
 
 ### 6.1 Prefer usability over aggression

--- a/docs/en-US/README.md
+++ b/docs/en-US/README.md
@@ -68,6 +68,14 @@ Expected CSV format:
 timestamp_ms,setpoint,input,pwm,error,p,i,d
 ```
 
+If you use one of the built-in hardware profile adapters, set `HARDWARE_PROFILE` explicitly in `config.json`:
+
+- `generic_serial_csv`: default CSV serial telemetry, suitable for `firmware.cpp` and demo mode
+- `stm32f407_openmv`: STM32F407 + OpenMV aiming/targeting telemetry, including `Status:` snapshots, `T:x,y`, and `N`
+- `mspm0_datavision`: MSPM0 DataVision telemetry, currently read-only and does not write PID values back to hardware
+
+If you omit this field, the app uses `generic_serial_csv`.
+
 ### 3. Run the exe once
 
 Double-click `llm-pid-tuner.exe`.
@@ -86,6 +94,7 @@ At minimum, start with the hardware-mode fields below:
 {
   "SERIAL_PORT": "AUTO",
   "BAUD_RATE": 115200,
+  "HARDWARE_PROFILE": "generic_serial_csv",
   "LLM_API_KEY": "sk-your-key",
   "LLM_API_BASE_URL": "https://api.openai.com/v1",
   "LLM_MODEL_NAME": "gpt-4o",
@@ -158,6 +167,7 @@ If you prefer starting from a template, check `config.example.json`.
 {
   "SERIAL_PORT": "AUTO",
   "BAUD_RATE": 115200,
+  "HARDWARE_PROFILE": "generic_serial_csv",
   "LLM_API_KEY": "sk-your-key",
   "LLM_API_BASE_URL": "https://api.openai.com/v1",
   "LLM_MODEL_NAME": "gpt-4o",
@@ -204,7 +214,7 @@ If your Simulink model is not the simplest "single standard PID Controller block
 
 | Group | When needed | Fields | Notes |
 | :---- | :---------- | :----- | :---- |
-| Serial hardware | Real hardware tuning | `SERIAL_PORT` `BAUD_RATE` | Start with `SERIAL_PORT: "AUTO"` and match the firmware baud rate |
+| Serial hardware | Real hardware tuning | `SERIAL_PORT` `BAUD_RATE` `HARDWARE_PROFILE` | Start with `SERIAL_PORT: "AUTO"` and match the firmware baud rate. Keep `HARDWARE_PROFILE=generic_serial_csv` for regular CSV firmware |
 | LLM basics | Required in every mode | `LLM_API_KEY` `LLM_API_BASE_URL` `LLM_MODEL_NAME` `LLM_PROVIDER` | This is the core set needed for any tuning run |
 | Tuning behavior | Optional | `BUFFER_SIZE` `MIN_ERROR_THRESHOLD` `MAX_TUNING_ROUNDS` `LLM_REQUEST_TIMEOUT` `LLM_DEBUG_OUTPUT` `PID_MAX_INCREASE_RATIO` `GOOD_ENOUGH_AVG_ERROR` `GOOD_ENOUGH_STEADY_STATE_ERROR` `GOOD_ENOUGH_OVERSHOOT` `REQUIRED_STABLE_ROUNDS` | Leave defaults unless you are tuning strategy or debugging. `PID_MAX_INCREASE_RATIO` limits the maximum multiplier for one adjustment. `GOOD_ENOUGH_*` defines the "good enough" thresholds, and `REQUIRED_STABLE_ROUNDS` is the number of consecutive stable evaluations before stopping. The default is 3. |
 | Simulink | MATLAB/Simulink mode only | `MATLAB_MODEL_PATH` `MATLAB_PID_BLOCK_PATH` `MATLAB_ROOT` `MATLAB_OUTPUT_SIGNAL` `MATLAB_SIM_STEP_TIME` `MATLAB_SETPOINT`, plus optional `MATLAB_CONTROL_SIGNAL` `MATLAB_SETPOINT_BLOCK` `MATLAB_PID_BLOCK_PATHS` `MATLAB_PID_BLOCK_PATH_2` `MATLAB_P/I/D_BLOCK_PATH(_2)` | Start with the minimum six fields, then add compatibility fields only when needed |

--- a/docs/zh-CN/PROJECT_DOC.md
+++ b/docs/zh-CN/PROJECT_DOC.md
@@ -171,6 +171,14 @@ timestamp_ms,setpoint,input,pwm,error,p,i,d
 
 如果你的硬件协议和这个不一致，优先建议从 `firmware.cpp` 同步，而不是在上位机里临时打补丁。
 
+硬件模式还支持通过 `HARDWARE_PROFILE` 选择内置协议适配器：
+
+- `generic_serial_csv`：默认值，继续使用上面的 CSV 协议。
+- `stm32f407_openmv`：适配 STM32F407 + OpenMV 文本遥测，包括 `Status:` 快照、`T:x,y` 和 `N`。
+- `mspm0_datavision`：适配 MSPM0 DataVision 二进制遥测帧。当前为只读遥测模式，在确认写回协议前不会向硬件发送 PID 参数。
+
+如果没有特殊硬件协议需求，请保持 `HARDWARE_PROFILE=generic_serial_csv`，这样原有使用方式不变。
+
 ## 6. 关键设计取向
 
 ### 6.1 优先可用，而不是盲目激进


### PR DESCRIPTION
## Summary
- Document the new `HARDWARE_PROFILE` field in the Chinese and English READMEs.
- Clarify that `generic_serial_csv` remains the default, so existing CSV firmware workflows are unchanged.
- Document the `stm32f407_openmv` and `mspm0_datavision` built-in adapters, with MSPM0 explicitly described as read-only telemetry for now.
- Add matching protocol notes to the Chinese and English project docs.

## Validation
- `git diff --check`
- `C:\Users\Administrator\conda-envs\matlab310\python.exe -m unittest tests.test_regression.ConfigLoadTests -v`