### PR TITLE
feat: add runtime setpoint control

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ timestamp_ms,setpoint,input,pwm,error,p,i,d
 - `stm32f407_openmv`：STM32F407 + OpenMV 瞄准链路，支持 `Status:` 文本、`T:x,y` 和 `N`
 - `mspm0_datavision`：MSPM0 DataVision 采样链路，当前是只读遥测模式，不向硬件写回 PID 参数
 
+在 TUI 调参过程中可以按 `t` 输入新的目标值，观察当前 PID 参数面对目标变化时的响应。默认 `generic_serial_csv` / `firmware.cpp` 路径会通过串口发送 `SETPOINT:<value>`；`mspm0_datavision` 仍保持只读。
+
 ### 第 3 步：第一次运行 exe
 
 双击运行 `llm-pid-tuner.exe`。
@@ -186,6 +188,8 @@ timestamp_ms,setpoint,input,pwm,error,p,i,d
 - 当系统“已经够好”时，会尽量提前停止，避免过调
 
 当一轮评测同时满足 `GOOD_ENOUGH_AVG_ERROR`、`GOOD_ENOUGH_STEADY_STATE_ERROR` 和 `GOOD_ENOUGH_OVERSHOOT` 时，程序会保持当前 PID 参数进入观察轮，而不是继续请求 LLM 改参数。连续 `REQUIRED_STABLE_ROUNDS` 轮评测都稳定后停止，默认是 3 轮；如果观察过程中响应变差，稳定计数会清零并恢复正常调参。
+
+TUI 模式下可以按 `t` 修改运行时目标值，用来测试当前参数对目标值变化的跟踪效果。
 
 你最终需要做的事通常只有一件：**把收敛后的 PID 参数写回你的固件。**
 

--- a/core/adapters.py
+++ b/core/adapters.py
@@ -8,12 +8,28 @@ from hw.profiles import (
     normalize_hardware_profile,
 )
 
+def _consume_requested_setpoint(controller: Any) -> Optional[float]:
+    if controller is None or not hasattr(controller, "consume_setpoint_request"):
+        return None
+    requested = controller.consume_setpoint_request()
+    if requested is None:
+        return None
+    return float(requested)
+
 class PythonSimEnv(BaseTuningEnvironment):
     def __init__(self, sim: Any, setpoint: float, controller: Any = None):
         self.sim = sim
-        self._setpoint = setpoint
+        self._setpoint = float(setpoint)
         self.controller = controller
         self.prompt_context = {}
+        self.last_setpoint_issue = ""
+        self.last_setpoint_message = ""
+
+    def _apply_requested_setpoint(self) -> None:
+        requested = _consume_requested_setpoint(self.controller)
+        if requested is None:
+            return
+        self.set_setpoint(requested)
 
     def collect_samples(self) -> List[Dict[str, float]]:
         samples = []
@@ -25,6 +41,7 @@ class PythonSimEnv(BaseTuningEnvironment):
             if self.controller and getattr(self.controller, "should_stop", False):
                 return samples
 
+            self._apply_requested_setpoint()
             self.sim.compute_pid()
             self.sim.update()
             data = self.sim.get_data()
@@ -47,7 +64,23 @@ class PythonSimEnv(BaseTuningEnvironment):
         return {"p": self.sim.kp, "i": self.sim.ki, "d": self.sim.kd}, None
 
     def get_setpoint(self) -> float:
-        return self._setpoint
+        try:
+            return float(getattr(self.sim, "setpoint", self._setpoint))
+        except (TypeError, ValueError):
+            return self._setpoint
+
+    def set_setpoint(self, setpoint: float) -> bool:
+        self.last_setpoint_issue = ""
+        value = float(setpoint)
+        if hasattr(self.sim, "set_setpoint"):
+            self.sim.set_setpoint(value)
+        else:
+            setattr(self.sim, "setpoint", value)
+            if hasattr(self.sim, "base_setpoint"):
+                setattr(self.sim, "base_setpoint", value)
+        self._setpoint = value
+        self.last_setpoint_message = f"Setpoint changed to {value:g}."
+        return True
 
     def get_prompt_context(self) -> Dict[str, Any]:
         return self.prompt_context
@@ -61,10 +94,18 @@ class PythonSimEnv(BaseTuningEnvironment):
 class SimulinkEnv(BaseTuningEnvironment):
     def __init__(self, bridge: Any, setpoint: float, controller: Any = None):
         self.bridge = bridge
-        self._setpoint = setpoint
+        self._setpoint = float(setpoint)
         self.controller = controller
         self.prompt_context = {}
         self.last_apply_issue = ""
+        self.last_setpoint_issue = ""
+        self.last_setpoint_message = ""
+
+    def _apply_requested_setpoint(self) -> None:
+        requested = _consume_requested_setpoint(self.controller)
+        if requested is None:
+            return
+        self.set_setpoint(requested)
 
     def _bridge_gain(self, *names: str, default: float) -> float:
         for name in names:
@@ -92,6 +133,7 @@ class SimulinkEnv(BaseTuningEnvironment):
             if run_count > max_run_steps:
                 raise RuntimeError("Simulink data collection timed out.")
                 
+            self._apply_requested_setpoint()
             self.bridge.run_step()
             batch = self.bridge.get_data()
             for data in batch:
@@ -135,7 +177,27 @@ class SimulinkEnv(BaseTuningEnvironment):
         return primary, secondary
 
     def get_setpoint(self) -> float:
-        return self._setpoint
+        try:
+            return float(getattr(self.bridge, "setpoint", self._setpoint))
+        except (TypeError, ValueError):
+            return self._setpoint
+
+    def set_setpoint(self, setpoint: float) -> bool:
+        self.last_setpoint_issue = ""
+        value = float(setpoint)
+        try:
+            if hasattr(self.bridge, "set_setpoint"):
+                self.bridge.set_setpoint(value)
+            else:
+                setattr(self.bridge, "setpoint", value)
+                if hasattr(self.bridge, "_apply_model_setpoint"):
+                    self.bridge._apply_model_setpoint()
+            self._setpoint = value
+            self.last_setpoint_message = f"Setpoint changed to {value:g}."
+            return True
+        except Exception as exc:
+            self.last_setpoint_issue = f"Failed to update Simulink setpoint: {exc}"
+            return False
 
     def get_prompt_context(self) -> Dict[str, Any]:
         return self.prompt_context
@@ -156,11 +218,20 @@ class HardwareEnv(BaseTuningEnvironment):
         self.bridge = bridge
         self.current_pid = dict(initial_pid)
         self.current_secondary_pid: Optional[Dict[str, float]] = None
+        self.current_setpoint = 0.0
         self.controller = controller
         self.prompt_context = {}
         self.last_collect_issue = ""
         self.last_collect_warning = ""
         self.last_apply_issue = ""
+        self.last_setpoint_issue = ""
+        self.last_setpoint_message = ""
+
+    def _apply_requested_setpoint(self) -> None:
+        requested = _consume_requested_setpoint(self.controller)
+        if requested is None:
+            return
+        self.set_setpoint(requested)
 
     def collect_samples(self) -> List[Dict[str, float]]:
         samples = []
@@ -182,6 +253,7 @@ class HardwareEnv(BaseTuningEnvironment):
             if self.controller and getattr(self.controller, "should_stop", False):
                 return samples
 
+            self._apply_requested_setpoint()
             if (time.time() - started_at) >= timeout_sec:
                 if len(samples) >= int(self.MIN_SAMPLES_PER_ROUND):
                     self.last_collect_warning = (
@@ -219,6 +291,8 @@ class HardwareEnv(BaseTuningEnvironment):
                             "i": float(data["i"]),
                             "d": float(data["d"]),
                         }
+                    if "setpoint" in data:
+                        self.current_setpoint = float(data["setpoint"])
                     if all(key in data for key in ("p2", "i2", "d2")):
                         self.current_secondary_pid = {
                             "p": float(data["p2"]),
@@ -295,7 +369,41 @@ class HardwareEnv(BaseTuningEnvironment):
         return dict(self.current_pid), secondary
 
     def get_setpoint(self) -> float:
-        return 0.0 # Handled by hardware
+        return self.current_setpoint
+
+    def set_setpoint(self, setpoint: float) -> bool:
+        self.last_setpoint_issue = ""
+        self.last_setpoint_message = ""
+        value = float(setpoint)
+        hardware_profile = normalize_hardware_profile(
+            getattr(self.bridge, "hardware_profile", DEFAULT_HARDWARE_PROFILE)
+        )
+
+        if hardware_profile == "mspm0_datavision":
+            self.last_setpoint_issue = (
+                "MSPM0 DataVision profile is read-only: setpoint write-back is disabled "
+                "until a command protocol is confirmed."
+            )
+            return False
+
+        if hasattr(self.bridge, "send_profile_command"):
+            sent = self.bridge.send_profile_command("SETPOINT", setpoint=value)
+            if sent is False:
+                self.last_setpoint_issue = (
+                    f"Failed to apply hardware setpoint: {self.bridge.last_error or 'unknown write error'}"
+                )
+                return False
+        else:
+            sent = self.bridge.send_command(f"SETPOINT:{value:g}")
+            if sent is False:
+                self.last_setpoint_issue = (
+                    f"Failed to apply hardware setpoint: {self.bridge.last_error or 'unknown write error'}"
+                )
+                return False
+
+        self.current_setpoint = value
+        self.last_setpoint_message = f"Setpoint changed to {value:g}."
+        return True
 
     def get_prompt_context(self) -> Dict[str, Any]:
         return self.prompt_context

--- a/core/env.py
+++ b/core/env.py
@@ -30,6 +30,10 @@ class BaseTuningEnvironment(ABC):
         """Return the current target setpoint."""
         pass
 
+    def set_setpoint(self, setpoint: float) -> bool:
+        """Try to update the target setpoint at runtime."""
+        return False
+
     @abstractmethod
     def get_prompt_context(self) -> Dict[str, Any]:
         """Return context metadata for LLM prompt generation."""

--- a/core/tuning_engine.py
+++ b/core/tuning_engine.py
@@ -31,6 +31,39 @@ def _emit_lifecycle(event_sink: Optional[QueueEventSink], start_time: float, pha
 def _emit_log(event_sink: Optional[QueueEventSink], start_time: float, level: str, message: str) -> None:
     publish_event(event_sink, "log", timestamp=time.time() - start_time, level=level, message=message)
 
+def _emit_setpoint_feedback(
+    env: BaseTuningEnvironment,
+    event_sink: Optional[QueueEventSink],
+    start_time: float,
+    emit_console: bool,
+) -> None:
+    message = str(getattr(env, "last_setpoint_message", "") or "").strip()
+    issue = str(getattr(env, "last_setpoint_issue", "") or "").strip()
+    if message:
+        _console(emit_console, f"[Setpoint] {message}")
+        publish_event(
+            event_sink,
+            "lifecycle",
+            timestamp=time.time() - start_time,
+            phase="setpoint",
+            detail=message,
+            message=message,
+            elapsed_sec=time.time() - start_time,
+        )
+        setattr(env, "last_setpoint_message", "")
+    if issue:
+        _console(emit_console, f"[WARN] {issue}")
+        publish_event(
+            event_sink,
+            "lifecycle",
+            timestamp=time.time() - start_time,
+            phase="setpoint_warning",
+            detail=issue,
+            message=issue,
+            elapsed_sec=time.time() - start_time,
+        )
+        setattr(env, "last_setpoint_issue", "")
+
 def _emit_sample_event(event_sink: Optional[QueueEventSink], data: Dict[str, float]) -> None:
     publish_event(
         event_sink,
@@ -138,6 +171,7 @@ def run_tuning_engine(
             
             session.buffer.reset()
             samples = env.collect_samples()
+            _emit_setpoint_feedback(env, event_sink, start_time, emit_console)
             collect_warning = str(getattr(env, "last_collect_warning", "") or "").strip()
             if collect_warning:
                 _console(emit_console, f"[WARN] {collect_warning}")

--- a/docs/en-US/PROJECT_DOC.md
+++ b/docs/en-US/PROJECT_DOC.md
@@ -177,6 +177,8 @@ Hardware mode can also select a built-in protocol adapter through `HARDWARE_PROF
 
 If you do not need a special hardware protocol, keep `HARDWARE_PROFILE=generic_serial_csv`; the existing workflow stays unchanged.
 
+In TUI mode, press `t` to change the runtime setpoint. For the default `generic_serial_csv` protocol, the host sends `SETPOINT:<value>`, and the example `firmware.cpp` updates its target accordingly; read-only profiles do not perform setpoint write-back.
+
 ## 6. Key Design Principles
 
 ### 6.1 Prefer usability over aggression

--- a/docs/en-US/README.md
+++ b/docs/en-US/README.md
@@ -76,6 +76,8 @@ If you use one of the built-in hardware profile adapters, set `HARDWARE_PROFILE`
 
 If you omit this field, the app uses `generic_serial_csv`.
 
+In TUI mode, press `t` to enter a new runtime setpoint and observe how the current PID values handle a target change. The default `generic_serial_csv` / `firmware.cpp` path sends `SETPOINT:<value>` over serial; `mspm0_datavision` remains read-only.
+
 ### 3. Run the exe once
 
 Double-click `llm-pid-tuner.exe`.
@@ -148,6 +150,8 @@ The app will:
 - stop early when the system is already “good enough”
 
 When one evaluation round satisfies `GOOD_ENOUGH_AVG_ERROR`, `GOOD_ENOUGH_STEADY_STATE_ERROR`, and `GOOD_ENOUGH_OVERSHOOT`, the app keeps the current PID values and enters observation rounds instead of asking the LLM for another adjustment. It stops after `REQUIRED_STABLE_ROUNDS` consecutive stable evaluations, which defaults to 3; if the response gets worse during observation, the stable counter resets and normal LLM tuning resumes.
+
+In TUI mode, press `t` to change the runtime setpoint and test how the current PID values track a target change.
 
 In practice, this means the tool tries to be useful on real hardware, not just aggressive.
 

--- a/docs/zh-CN/PROJECT_DOC.md
+++ b/docs/zh-CN/PROJECT_DOC.md
@@ -179,6 +179,8 @@ timestamp_ms,setpoint,input,pwm,error,p,i,d
 
 如果没有特殊硬件协议需求，请保持 `HARDWARE_PROFILE=generic_serial_csv`，这样原有使用方式不变。
 
+TUI 运行时支持按 `t` 修改目标值。对默认 `generic_serial_csv` 协议，上位机会发送 `SETPOINT:<value>`，示例 `firmware.cpp` 会据此更新目标值；只读 profile 不会执行 setpoint 写回。
+
 ## 6. 关键设计取向
 
 ### 6.1 优先可用，而不是盲目激进

--- a/hw/bridge.py
+++ b/hw/bridge.py
@@ -101,6 +101,7 @@ class _DemoSerialDevice:
         r"SET2\s+P:(?P<p>-?\d+(?:\.\d+)?)\s+I:(?P<i>-?\d+(?:\.\d+)?)\s+D:(?P<d>-?\d+(?:\.\d+)?)",
         re.IGNORECASE,
     )
+    _setpoint_re = re.compile(r"SETPOINT:(?P<setpoint>-?\d+(?:\.\d+)?)", re.IGNORECASE)
 
     def __init__(self) -> None:
         from sim.model import HeatingSimulator
@@ -161,6 +162,11 @@ class _DemoSerialDevice:
                 "i": float(match2.group("i")),
                 "d": float(match2.group("d")),
             }
+            return
+
+        setpoint_match = self._setpoint_re.fullmatch(command)
+        if setpoint_match:
+            self._sim.set_setpoint(float(setpoint_match.group("setpoint")))
 
 
 class SerialBridge:
@@ -285,12 +291,14 @@ class SerialBridge:
         kind: str,
         primary_pid: Optional[Dict[str, float]] = None,
         secondary_pid: Optional[Dict[str, float]] = None,
+        setpoint: Optional[float] = None,
     ) -> bool:
         commands = build_profile_commands(
             self.hardware_profile,
             kind,
             primary_pid=primary_pid,
             secondary_pid=secondary_pid,
+            setpoint=setpoint,
         )
         if not commands:
             self.last_error = (

--- a/hw/profiles.py
+++ b/hw/profiles.py
@@ -98,6 +98,7 @@ def build_profile_commands(
     kind: str,
     primary_pid: Optional[Dict[str, float]] = None,
     secondary_pid: Optional[Dict[str, float]] = None,
+    setpoint: Optional[float] = None,
 ) -> List[str]:
     normalized = normalize_hardware_profile(profile)
     command_kind = str(kind or "").strip().upper()
@@ -106,6 +107,11 @@ def build_profile_commands(
 
     if command_kind == "STATUS":
         return ["status"] if normalized == "stm32f407_openmv" else ["STATUS"]
+
+    if command_kind == "SETPOINT":
+        if normalized == DEFAULT_HARDWARE_PROFILE and setpoint is not None:
+            return [f"SETPOINT:{float(setpoint):g}"]
+        return []
 
     if command_kind not in {"SET", "SET2"}:
         return []

--- a/sim/model.py
+++ b/sim/model.py
@@ -41,15 +41,25 @@ class HeatingSimulator:
         self.noise_level = 0.1
         self.rng = random.Random(random_seed)
         self.step_count = 0
+        self.dynamic_setpoint_enabled = True
 
     def set_pid(self, kp: float, ki: float, kd: float) -> None:
         self.kp = kp
         self.ki = ki
         self.kd = kd
 
+    def set_setpoint(self, setpoint: float) -> None:
+        self.base_setpoint = float(setpoint)
+        self.setpoint = float(setpoint)
+        self.dynamic_setpoint_enabled = False
+
     def compute_pid(self) -> None:
         # Dynamic setpoint: step change every 50 steps (10 seconds)
-        if self.step_count > 0 and self.step_count % 50 == 0:
+        if (
+            self.dynamic_setpoint_enabled
+            and self.step_count > 0
+            and self.step_count % 50 == 0
+        ):
             if self.setpoint == self.base_setpoint:
                 self.setpoint = self.base_setpoint + 50.0
             else:

--- a/sim/runtime.py
+++ b/sim/runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import field
+import math
 from queue import Empty, Queue
 import threading
 import time
@@ -57,6 +58,8 @@ class QueueEventSink:
 class SimulationController:
     stop_event: threading.Event = field(default_factory=threading.Event)
     run_event: threading.Event = field(default_factory=threading.Event)
+    _setpoint_lock: threading.Lock = field(default_factory=threading.Lock)
+    _requested_setpoint: float | None = None
 
     def __post_init__(self) -> None:
         self.run_event.set()
@@ -102,6 +105,20 @@ class SimulationController:
     def request_stop(self) -> None:
         self.stop_event.set()
         self.run_event.set()
+
+    def request_setpoint(self, setpoint: float) -> float:
+        value = float(setpoint)
+        if not math.isfinite(value):
+            raise ValueError("setpoint must be finite")
+        with self._setpoint_lock:
+            self._requested_setpoint = value
+        return value
+
+    def consume_setpoint_request(self) -> float | None:
+        with self._setpoint_lock:
+            value = self._requested_setpoint
+            self._requested_setpoint = None
+            return value
 
     def wait_until_running(self, poll_interval: float = 0.05) -> bool:
         while not self.stop_event.is_set():

--- a/sim/simulink_bridge.py
+++ b/sim/simulink_bridge.py
@@ -677,6 +677,10 @@ class SimulinkBridge:
         self.setpoint_block = block_path
         print(f"[Simulink] Synced setpoint {self.setpoint} to {block_path} ({parameter_name}).")
 
+    def set_setpoint(self, setpoint: float) -> None:
+        self.setpoint = float(setpoint)
+        self._apply_model_setpoint()
+
     def _to_float_scalar(self, value: object) -> float:
         session = self._ensure_session()
         if session is not None:

--- a/sim/tui.py
+++ b/sim/tui.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import deque
 from dataclasses import field
+import math
 import threading
 import time
 from queue import Queue
@@ -11,9 +12,10 @@ from rich.markup import escape as markup_escape
 from core.compat import slotted_dataclass
 from core.i18n import get_language
 from textual.app import App, ComposeResult
-from textual.containers import Horizontal
+from textual.containers import Horizontal, Vertical
 from textual.css.query import NoMatches
-from textual.widgets import RichLog, Static
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, RichLog, Static
 
 from sim.runtime import (
     EVENT_DECISION,
@@ -75,8 +77,15 @@ TRANSLATIONS: Dict[str, Dict[str, str]] = {
         "help_l": "日志详情",
         "help_r": "清空视图",
         "help_n": "下一轮",
+        "help_t": "设置目标",
         "help_browse": "滚轮 / PgUp / PgDn / ↑↓  浏览日志",
         "help_done": "调参完成，按 n 可以上次结果为起点继续新一轮",
+        "setpoint_prompt": "输入新的目标值",
+        "setpoint_placeholder": "例如 200",
+        "setpoint_apply": "应用",
+        "setpoint_cancel": "取消",
+        "setpoint_invalid": "请输入有限数字。",
+        "setpoint_requested": "已请求目标值: {setpoint:g}",
         # booleans
         "paused_yes": "是",
         "paused_no": "否",
@@ -134,8 +143,15 @@ TRANSLATIONS: Dict[str, Dict[str, str]] = {
         "help_l": "Log Detail",
         "help_r": "Reset View",
         "help_n": "Next Round",
+        "help_t": "Set SP",
         "help_browse": "Wheel / PgUp / PgDn / ↑↓  browse log",
         "help_done": "Tuning done. Press n to start another round from the last result.",
+        "setpoint_prompt": "Enter a new setpoint",
+        "setpoint_placeholder": "e.g. 200",
+        "setpoint_apply": "Apply",
+        "setpoint_cancel": "Cancel",
+        "setpoint_invalid": "Enter a finite number.",
+        "setpoint_requested": "Setpoint requested: {setpoint:g}",
         # booleans
         "paused_yes": "yes",
         "paused_no": "no",
@@ -441,6 +457,8 @@ class PanelState:
             + sep
             + hk("p", self.tr("help_p"))
             + sep
+            + hk("t", self.tr("help_t"))
+            + sep
             + hk("l", self.tr("help_l"))
             + sep
             + hk("r", self.tr("help_r"))
@@ -529,6 +547,110 @@ class PanelState:
 
 
 # ---------------------------------------------------------------------------
+# Runtime setpoint dialog
+# ---------------------------------------------------------------------------
+class SetpointDialog(ModalScreen[Optional[float]]):
+    CSS = """
+    SetpointDialog {
+        align: center middle;
+    }
+
+    #setpoint-dialog {
+        width: 44;
+        height: auto;
+        border: round $accent;
+        padding: 1 2;
+        background: $surface;
+    }
+
+    #setpoint-input {
+        margin-top: 1;
+    }
+
+    #setpoint-error {
+        height: 1;
+        color: $error;
+    }
+
+    #setpoint-buttons {
+        height: 3;
+        align-horizontal: right;
+    }
+    """
+
+    BINDINGS = [("escape", "cancel", "Cancel")]
+
+    def __init__(
+        self,
+        *,
+        current_setpoint: float,
+        language: str,
+        translations: Dict[str, Dict[str, str]],
+    ) -> None:
+        super().__init__()
+        self.current_setpoint = float(current_setpoint)
+        self.language = language
+        self.translations = translations
+
+    def tr(self, key: str) -> str:
+        lang = self.language if self.language in self.translations else "en"
+        return self.translations[lang][key]
+
+    def compose(self) -> ComposeResult:
+        initial = "" if abs(self.current_setpoint) < 1e-12 else f"{self.current_setpoint:g}"
+        yield Vertical(
+            Static(self.tr("setpoint_prompt")),
+            Input(
+                value=initial,
+                placeholder=self.tr("setpoint_placeholder"),
+                id="setpoint-input",
+            ),
+            Static("", id="setpoint-error"),
+            Horizontal(
+                Button(self.tr("setpoint_apply"), id="setpoint-apply", variant="primary"),
+                Button(self.tr("setpoint_cancel"), id="setpoint-cancel"),
+                id="setpoint-buttons",
+            ),
+            id="setpoint-dialog",
+        )
+
+    def on_mount(self) -> None:
+        try:
+            self.query_one("#setpoint-input", Input).focus()
+        except NoMatches:
+            return
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    def on_input_submitted(self, _event: Input.Submitted) -> None:
+        self._submit()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "setpoint-cancel":
+            self.dismiss(None)
+            return
+        if event.button.id == "setpoint-apply":
+            self._submit()
+
+    def _submit(self) -> None:
+        try:
+            raw_value = self.query_one("#setpoint-input", Input).value.strip()
+            value = float(raw_value)
+            if not math.isfinite(value):
+                raise ValueError
+        except (NoMatches, TypeError, ValueError):
+            try:
+                self.query_one("#setpoint-error", Static).update(
+                    self.tr("setpoint_invalid")
+                )
+            except NoMatches:
+                pass
+            return
+        self.dismiss(value)
+
+
+# ---------------------------------------------------------------------------
 # TUI Application
 # ---------------------------------------------------------------------------
 class SimulationTUIApp(App[None]):
@@ -576,6 +698,7 @@ class SimulationTUIApp(App[None]):
         ("q", "request_quit", "Quit"),
         ("s", "save_and_exit", "Save and exit"),
         ("p", "toggle_pause", "Pause"),
+        ("t", "change_setpoint", "Setpoint"),
         ("l", "toggle_event_detail", "Log detail"),
         ("r", "reset_view", "Reset view"),
         ("n", "next_round", "Next round"),
@@ -864,6 +987,39 @@ class SimulationTUIApp(App[None]):
         )
         self._log_requires_full_refresh = True
         self._refresh_all()
+
+    def action_change_setpoint(self) -> None:
+        if self.state.tuning_done or not self._worker_is_running():
+            return
+
+        def on_setpoint(value: Optional[float]) -> None:
+            if value is None:
+                return
+            try:
+                requested = self.controller.request_setpoint(value)
+            except ValueError:
+                return
+            self.state.current_setpoint = requested
+            message = self.state.tr("setpoint_requested").format(setpoint=requested)
+            self.state.apply_event(
+                {
+                    "type": EVENT_LIFECYCLE,
+                    "phase": "setpoint_requested",
+                    "message": message,
+                    "elapsed_sec": self.state.elapsed_sec,
+                }
+            )
+            self._log_requires_full_refresh = True
+            self._refresh_all()
+
+        self.push_screen(
+            SetpointDialog(
+                current_setpoint=self.state.current_setpoint,
+                language=self.state.language,
+                translations=TRANSLATIONS,
+            ),
+            callback=on_setpoint,
+        )
 
     def action_toggle_event_detail(self) -> None:
         self.state.detailed_events = not self.state.detailed_events

--- a/tests/test_hardware_tui.py
+++ b/tests/test_hardware_tui.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import tuner
+from hw.profiles import build_profile_commands
 from sim.runtime import (
     EVENT_DECISION,
     EVENT_LIFECYCLE,
@@ -815,6 +816,58 @@ class HardwareTuiLoopTests(unittest.TestCase):
         self.assertEqual(current_pid, {"p": 1.0, "i": 0.1, "d": 0.05})
         self.assertIsNone(secondary_pid)
         self.assertIn("read-only", env.last_apply_issue)
+
+    def test_generic_profile_builds_setpoint_command(self):
+        self.assertEqual(
+            build_profile_commands("generic_serial_csv", "SETPOINT", setpoint=225.0),
+            ["SETPOINT:225"],
+        )
+
+    def test_hardware_env_sends_runtime_setpoint_for_generic_profile(self):
+        calls = []
+
+        class GenericBridge:
+            hardware_profile = "generic_serial_csv"
+            last_error = ""
+
+            def send_profile_command(self, kind, **kwargs):
+                calls.append((kind, kwargs))
+                return True
+
+            def disconnect(self):
+                return None
+
+        env = tuner.HardwareEnv(
+            GenericBridge(),
+            {"p": 1.0, "i": 0.1, "d": 0.05},
+        )
+
+        applied = env.set_setpoint(225.0)
+
+        self.assertTrue(applied)
+        self.assertEqual(calls, [("SETPOINT", {"setpoint": 225.0})])
+        self.assertEqual(env.get_setpoint(), 225.0)
+        self.assertIn("225", env.last_setpoint_message)
+
+    def test_mspm0_setpoint_write_is_rejected(self):
+        class Mspm0Bridge:
+            hardware_profile = "mspm0_datavision"
+            last_error = ""
+
+            def send_profile_command(self, *_args, **_kwargs):
+                raise AssertionError("MSPM0 telemetry-only profile must not write setpoint")
+
+            def disconnect(self):
+                return None
+
+        env = tuner.HardwareEnv(
+            Mspm0Bridge(),
+            {"p": 1.0, "i": 0.1, "d": 0.05},
+        )
+
+        self.assertFalse(env.set_setpoint(225.0))
+        self.assertEqual(env.get_setpoint(), 0.0)
+        self.assertIn("read-only", env.last_setpoint_issue)
 
     def test_hardware_env_uses_fixed_sampling_thresholds(self):
         class EmptyBridge:

--- a/tests/test_simulator_tui.py
+++ b/tests/test_simulator_tui.py
@@ -7,6 +7,7 @@ import time
 import unittest
 from pathlib import Path
 from queue import Queue
+from types import SimpleNamespace
 from unittest.mock import patch
 
 
@@ -18,7 +19,7 @@ if TEXTUAL_AVAILABLE:
     from textual.widgets import RichLog, Static
 
 import simulator
-from core.adapters import SimulinkEnv
+from core.adapters import PythonSimEnv, SimulinkEnv
 from doctor import DoctorCheck
 from sim.model import HeatingSimulator, SETPOINT
 from sim.prompt_context import build_simulink_prompt_context
@@ -121,6 +122,14 @@ class SimulationControllerTests(unittest.TestCase):
         self.assertFalse(thread.is_alive())
         self.assertEqual(resumed, [True])
 
+    def test_setpoint_request_is_consumed_once(self):
+        controller = SimulationController()
+
+        controller.request_setpoint(240.0)
+
+        self.assertEqual(controller.consume_setpoint_request(), 240.0)
+        self.assertIsNone(controller.consume_setpoint_request())
+
 
 class SimulinkEnvTests(unittest.TestCase):
     def test_get_current_pid_reads_secondary_bridge_gains_from_secondary_attrs(self):
@@ -138,6 +147,65 @@ class SimulinkEnvTests(unittest.TestCase):
 
         self.assertEqual(primary, {"p": 1.0, "i": 0.1, "d": 0.05})
         self.assertEqual(secondary, {"p": 2.0, "i": 0.2, "d": 0.06})
+
+    def test_collect_samples_applies_requested_setpoint_before_run_step(self):
+        controller = SimulationController()
+        controller.request_setpoint(260.0)
+
+        class FakeBridge:
+            kp = 1.0
+            ki = 0.1
+            kd = 0.05
+            target_steps = 1
+
+            def __init__(self):
+                self.setpoint = 200.0
+                self._last_data = []
+
+            def set_setpoint(self, setpoint):
+                self.setpoint = float(setpoint)
+
+            def run_step(self):
+                self._last_data = [
+                    {
+                        "timestamp": 0.0,
+                        "setpoint": self.setpoint,
+                        "input": 180.0,
+                        "pwm": 0.0,
+                        "error": self.setpoint - 180.0,
+                        "p": self.kp,
+                        "i": self.ki,
+                        "d": self.kd,
+                    }
+                ]
+
+            def get_data(self):
+                return list(self._last_data)
+
+        env = SimulinkEnv(FakeBridge(), 200.0, controller=controller)
+
+        samples = env.collect_samples()
+
+        self.assertEqual(env.get_setpoint(), 260.0)
+        self.assertEqual(samples[0]["setpoint"], 260.0)
+        self.assertIn("260", env.last_setpoint_message)
+
+
+class PythonSimEnvTests(unittest.TestCase):
+    def test_collect_samples_applies_requested_setpoint(self):
+        controller = SimulationController()
+        controller.request_setpoint(240.0)
+        sim = HeatingSimulator(setpoint=200.0, random_seed=3)
+        sim.target_steps = 3
+        env = PythonSimEnv(sim, 200.0, controller=controller)
+
+        samples = env.collect_samples()
+
+        self.assertEqual(env.get_setpoint(), 240.0)
+        self.assertTrue(samples)
+        self.assertEqual(samples[0]["setpoint"], 240.0)
+        self.assertFalse(sim.dynamic_setpoint_enabled)
+        self.assertIn("240", env.last_setpoint_message)
 
 
 class SimulatorLoopTests(unittest.TestCase):
@@ -1569,6 +1637,40 @@ class TextualDashboardTests(unittest.IsolatedAsyncioTestCase):
             self.assertFalse(app.state.tuning_done)
             self.assertFalse(app._history_browsing_enabled)
             self.assertIn("q", help_text)
+
+    async def test_change_setpoint_action_queues_controller_request(self):
+        from sim.tui import SimulationTUIApp
+
+        event_queue = Queue()
+        event_sink = QueueEventSink(event_queue)
+        controller = SimulationController()
+        app = SimulationTUIApp(
+            event_queue=event_queue,
+            controller=controller,
+            worker_target=None,
+            event_sink=event_sink,
+            mode_label="Python",
+        )
+        callbacks = []
+        app._worker_thread = SimpleNamespace(is_alive=lambda: True)
+        app._refresh_all = lambda: None
+
+        def fake_push_screen(_screen, callback=None):
+            callbacks.append(callback)
+
+        app.push_screen = fake_push_screen
+
+        app.action_change_setpoint()
+        callbacks[0](245.0)
+
+        self.assertEqual(controller.consume_setpoint_request(), 245.0)
+        self.assertEqual(app.state.current_setpoint, 245.0)
+        self.assertTrue(
+            any(
+                event.get("phase") == "setpoint_requested"
+                for event in app.state.event_history
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_simulink_bridge.py
+++ b/tests/test_simulink_bridge.py
@@ -395,6 +395,21 @@ class SimulinkBridgeCompatTests(unittest.TestCase):
             bridge._eng.set_param_calls,
         )
 
+    def test_set_setpoint_updates_bridge_and_model_block(self):
+        bridge = self._make_bridge({})
+        bridge.setpoint_block = "demo/Setpoint"
+        bridge._eng.blocks = {
+            "demo/Setpoint": {"BlockType": "Constant", "Value": "0"},
+        }
+
+        bridge.set_setpoint(240.0)
+
+        self.assertEqual(bridge.setpoint, 240.0)
+        self.assertIn(
+            ("demo/Setpoint", "Value", "240.0"),
+            bridge._eng.set_param_calls,
+        )
+
 
     def test_set_pid_supports_kp_ki_kd_parameter_names(self):
         bridge = self._make_bridge({})

--- a/tests/test_tuning_engine.py
+++ b/tests/test_tuning_engine.py
@@ -235,6 +235,41 @@ class TuningEngineObservationTests(unittest.TestCase):
         self.assertEqual(pid_limits["p"]["max_increase_ratio"], 2.0)
         self.assertTrue(tuner.prompt_contexts[0]["pid_limits_are_runtime_enforced"])
 
+    def test_setpoint_feedback_is_published_as_lifecycle_event(self):
+        env = FakeEnv([good_samples()])
+        env.last_setpoint_message = "Setpoint changed to 240."
+        tuner = CountingTuner()
+        sink = QueueEventSink(Queue())
+        config = {
+            "BUFFER_SIZE": 3,
+            "MAX_TUNING_ROUNDS": 1,
+            "MIN_ERROR_THRESHOLD": 0.0,
+            "REQUIRED_STABLE_ROUNDS": 1,
+            "GOOD_ENOUGH_AVG_ERROR": 1.0,
+            "GOOD_ENOUGH_STEADY_STATE_ERROR": 0.5,
+            "GOOD_ENOUGH_OVERSHOOT": 2.0,
+        }
+
+        with patch.dict("core.tuning_engine.CONFIG", config, clear=False):
+            run_tuning_engine(
+                env,
+                tuner,
+                "python_sim",
+                event_sink=sink,
+                emit_console=False,
+            )
+
+        events = drain_event_queue(sink.event_queue)
+        self.assertTrue(
+            any(
+                event.get("type") == EVENT_LIFECYCLE
+                and event.get("phase") == "setpoint"
+                and event.get("message") == "Setpoint changed to 240."
+                for event in events
+            )
+        )
+        self.assertEqual(env.last_setpoint_message, "")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add a TUI runtime setpoint dialog on the `t` hotkey
- route setpoint requests through the shared controller/environment layer for Python sim, Simulink, and writable hardware profiles
- add `SETPOINT:<value>` support for the default generic serial profile and demo bridge; keep read-only profiles guarded
- document the new runtime setpoint control in Chinese and English docs

Fixes #41

## Tests
- `C:\Users\Administrator\conda-envs\matlab310\python.exe -m py_compile sim\runtime.py core\env.py sim\model.py core\adapters.py hw\profiles.py hw\bridge.py sim\simulink_bridge.py sim\tui.py core\tuning_engine.py`
- `C:\Users\Administrator\conda-envs\matlab310\python.exe -m unittest discover tests`