### PR TITLE
fix: harden runtime setpoint updates

### DIFF
--- a/core/adapters.py
+++ b/core/adapters.py
@@ -8,13 +8,13 @@ from hw.profiles import (
     normalize_hardware_profile,
 )
 
-def _consume_requested_setpoint(controller: Any) -> Optional[float]:
+def _apply_requested_setpoint(controller: Any, setter: Any) -> None:
     if controller is None or not hasattr(controller, "consume_setpoint_request"):
-        return None
+        return
     requested = controller.consume_setpoint_request()
     if requested is None:
-        return None
-    return float(requested)
+        return
+    setter(float(requested))
 
 class PythonSimEnv(BaseTuningEnvironment):
     def __init__(self, sim: Any, setpoint: float, controller: Any = None):
@@ -24,12 +24,6 @@ class PythonSimEnv(BaseTuningEnvironment):
         self.prompt_context = {}
         self.last_setpoint_issue = ""
         self.last_setpoint_message = ""
-
-    def _apply_requested_setpoint(self) -> None:
-        requested = _consume_requested_setpoint(self.controller)
-        if requested is None:
-            return
-        self.set_setpoint(requested)
 
     def collect_samples(self) -> List[Dict[str, float]]:
         samples = []
@@ -41,7 +35,7 @@ class PythonSimEnv(BaseTuningEnvironment):
             if self.controller and getattr(self.controller, "should_stop", False):
                 return samples
 
-            self._apply_requested_setpoint()
+            _apply_requested_setpoint(self.controller, self.set_setpoint)
             self.sim.compute_pid()
             self.sim.update()
             data = self.sim.get_data()
@@ -101,12 +95,6 @@ class SimulinkEnv(BaseTuningEnvironment):
         self.last_setpoint_issue = ""
         self.last_setpoint_message = ""
 
-    def _apply_requested_setpoint(self) -> None:
-        requested = _consume_requested_setpoint(self.controller)
-        if requested is None:
-            return
-        self.set_setpoint(requested)
-
     def _bridge_gain(self, *names: str, default: float) -> float:
         for name in names:
             if not hasattr(self.bridge, name):
@@ -133,7 +121,7 @@ class SimulinkEnv(BaseTuningEnvironment):
             if run_count > max_run_steps:
                 raise RuntimeError("Simulink data collection timed out.")
                 
-            self._apply_requested_setpoint()
+            _apply_requested_setpoint(self.controller, self.set_setpoint)
             self.bridge.run_step()
             batch = self.bridge.get_data()
             for data in batch:
@@ -185,17 +173,27 @@ class SimulinkEnv(BaseTuningEnvironment):
     def set_setpoint(self, setpoint: float) -> bool:
         self.last_setpoint_issue = ""
         value = float(setpoint)
+        previous_bridge_setpoint = getattr(self.bridge, "setpoint", self._setpoint)
+        used_legacy_fallback = not hasattr(self.bridge, "set_setpoint")
         try:
-            if hasattr(self.bridge, "set_setpoint"):
-                self.bridge.set_setpoint(value)
+            if not used_legacy_fallback:
+                applied = self.bridge.set_setpoint(value)
+                if applied is False:
+                    raise RuntimeError("Simulink bridge rejected the setpoint update.")
             else:
                 setattr(self.bridge, "setpoint", value)
                 if hasattr(self.bridge, "_apply_model_setpoint"):
-                    self.bridge._apply_model_setpoint()
+                    applied = self.bridge._apply_model_setpoint()
+                    if applied is False:
+                        raise RuntimeError(
+                            "No writable Simulink setpoint block was found."
+                        )
             self._setpoint = value
             self.last_setpoint_message = f"Setpoint changed to {value:g}."
             return True
         except Exception as exc:
+            if used_legacy_fallback:
+                setattr(self.bridge, "setpoint", previous_bridge_setpoint)
             self.last_setpoint_issue = f"Failed to update Simulink setpoint: {exc}"
             return False
 
@@ -227,12 +225,6 @@ class HardwareEnv(BaseTuningEnvironment):
         self.last_setpoint_issue = ""
         self.last_setpoint_message = ""
 
-    def _apply_requested_setpoint(self) -> None:
-        requested = _consume_requested_setpoint(self.controller)
-        if requested is None:
-            return
-        self.set_setpoint(requested)
-
     def collect_samples(self) -> List[Dict[str, float]]:
         samples = []
         target_size = CONFIG["BUFFER_SIZE"]
@@ -253,7 +245,7 @@ class HardwareEnv(BaseTuningEnvironment):
             if self.controller and getattr(self.controller, "should_stop", False):
                 return samples
 
-            self._apply_requested_setpoint()
+            _apply_requested_setpoint(self.controller, self.set_setpoint)
             if (time.time() - started_at) >= timeout_sec:
                 if len(samples) >= int(self.MIN_SAMPLES_PER_ROUND):
                     self.last_collect_warning = (

--- a/core/tuning_engine.py
+++ b/core/tuning_engine.py
@@ -236,7 +236,7 @@ def run_tuning_engine(
                     _console(emit_console, f"\n[ERROR] {rollback_apply_issue}")
                     _emit_lifecycle(event_sink, start_time, "error", rollback_apply_issue)
                     break
-                _console(emit_console, f"[CMD] Applied rollback PID.")
+                _console(emit_console, "[CMD] Applied rollback PID.")
                 continue
 
             if evaluation.completed_reason == "stable_rounds_reached" and not disable_early_exit:
@@ -392,7 +392,7 @@ def run_tuning_engine(
                 _console(emit_console, f"\n[ERROR] {apply_issue}")
                 _emit_lifecycle(event_sink, start_time, "error", apply_issue)
                 break
-            _console(emit_console, f"[CMD] Applied new PID parameters.")
+            _console(emit_console, "[CMD] Applied new PID parameters.")
             
         if (
             session.round_num >= CONFIG["MAX_TUNING_ROUNDS"]

--- a/hw/bridge.py
+++ b/hw/bridge.py
@@ -18,7 +18,6 @@ import serial.tools.list_ports
 from hw.profiles import (
     DEFAULT_HARDWARE_PROFILE,
     build_profile_commands,
-    get_hardware_board_family,
     get_hardware_profile_info,
     get_openmv_image_center,
     normalize_hardware_profile,

--- a/hw/profiles.py
+++ b/hw/profiles.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, List, Optional
 
 DEFAULT_HARDWARE_PROFILE = "generic_serial_csv"
 

--- a/sim/simulink_bridge.py
+++ b/sim/simulink_bridge.py
@@ -650,14 +650,14 @@ class SimulinkBridge:
         discovery = self._block_discovery or self._create_block_discovery()
         return discovery.setpoint_parameter_name(block_type)
 
-    def _apply_model_setpoint(self) -> None:
+    def _apply_model_setpoint(self) -> bool:
         block_path, block_type = self._resolve_setpoint_block()
         if not block_path or not block_type:
             print(
                 "[Simulink][WARN] Could not auto-detect the setpoint source block. "
                 f"Make sure the model setpoint matches MATLAB_SETPOINT={self.setpoint}."
             )
-            return
+            return False
 
         parameter_name = self._setpoint_parameter_name(block_type)
         if not parameter_name:
@@ -665,7 +665,7 @@ class SimulinkBridge:
                 f"[Simulink][WARN] Detected setpoint block {block_path}, "
                 f"but block type {block_type} is not writable yet."
             )
-            return
+            return False
 
         self._call_engine_method(
             "set_param",
@@ -676,10 +676,23 @@ class SimulinkBridge:
         )
         self.setpoint_block = block_path
         print(f"[Simulink] Synced setpoint {self.setpoint} to {block_path} ({parameter_name}).")
+        return True
 
-    def set_setpoint(self, setpoint: float) -> None:
+    def set_setpoint(self, setpoint: float) -> bool:
+        previous_setpoint = self.setpoint
         self.setpoint = float(setpoint)
-        self._apply_model_setpoint()
+        try:
+            applied = self._apply_model_setpoint()
+        except Exception:
+            self.setpoint = previous_setpoint
+            raise
+        if not applied:
+            self.setpoint = previous_setpoint
+            raise RuntimeError(
+                "Could not update the Simulink setpoint because no writable "
+                "setpoint block was found."
+            )
+        return True
 
     def _to_float_scalar(self, value: object) -> float:
         session = self._ensure_session()

--- a/tests/test_simulator_tui.py
+++ b/tests/test_simulator_tui.py
@@ -190,6 +190,32 @@ class SimulinkEnvTests(unittest.TestCase):
         self.assertEqual(samples[0]["setpoint"], 260.0)
         self.assertIn("260", env.last_setpoint_message)
 
+    def test_set_setpoint_reports_bridge_rejection_without_changing_value(self):
+        class RejectingBridge:
+            setpoint = 200.0
+
+            def set_setpoint(self, _setpoint):
+                return False
+
+        env = SimulinkEnv(RejectingBridge(), 200.0)
+
+        self.assertFalse(env.set_setpoint(260.0))
+        self.assertEqual(env.get_setpoint(), 200.0)
+        self.assertIn("rejected", env.last_setpoint_issue)
+
+    def test_legacy_setpoint_fallback_restores_value_when_apply_fails(self):
+        class LegacyBridge:
+            setpoint = 200.0
+
+            def _apply_model_setpoint(self):
+                return False
+
+        env = SimulinkEnv(LegacyBridge(), 200.0)
+
+        self.assertFalse(env.set_setpoint(260.0))
+        self.assertEqual(env.get_setpoint(), 200.0)
+        self.assertIn("No writable", env.last_setpoint_issue)
+
 
 class PythonSimEnvTests(unittest.TestCase):
     def test_collect_samples_applies_requested_setpoint(self):

--- a/tests/test_simulink_bridge.py
+++ b/tests/test_simulink_bridge.py
@@ -402,13 +402,23 @@ class SimulinkBridgeCompatTests(unittest.TestCase):
             "demo/Setpoint": {"BlockType": "Constant", "Value": "0"},
         }
 
-        bridge.set_setpoint(240.0)
+        applied = bridge.set_setpoint(240.0)
 
+        self.assertTrue(applied)
         self.assertEqual(bridge.setpoint, 240.0)
         self.assertIn(
             ("demo/Setpoint", "Value", "240.0"),
             bridge._eng.set_param_calls,
         )
+
+    def test_set_setpoint_restores_previous_value_when_block_is_missing(self):
+        bridge = self._make_bridge({})
+        previous_setpoint = bridge.setpoint
+
+        with self.assertRaisesRegex(RuntimeError, "no writable setpoint block"):
+            bridge.set_setpoint(240.0)
+
+        self.assertEqual(bridge.setpoint, previous_setpoint)
 
 
     def test_set_pid_supports_kp_ki_kd_parameter_names(self):


### PR DESCRIPTION
## Summary
- avoid false-success runtime setpoint updates when Simulink has no writable setpoint block
- restore the previous Simulink setpoint when a runtime update fails
- consolidate duplicated setpoint-request handling across environments
- remove minor unused imports and redundant f-string prefixes found during release review

## Validation
- C:\Users\Administrator\conda-envs\matlab310\python.exe -m pytest -q -p no:cacheprovider
- 339 passed, 11 subtests passed
- flake8 F/E9 check on changed production modules