### PR TITLE
feat: add OrcaRouter API-key and PKCE login

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,8 +334,64 @@ $env:LLM_PROVIDER="openai"
 | Ollama                           | `http://localhost:11434/v1` | `openai`        | 本地免费部署                                |
 | LM Studio                        | `http://localhost:1234/v1`  | `openai`        | 本地可视化较友好                            |
 | Anthropic Claude                 | `https://api.anthropic.com` | `anthropic`     | 原生接口用这个                              |
+| OrcaRouter（API Key）            | `https://api.orcarouter.ai/v1` | `orcarouter` | 粘贴已有的 `sk-orca-…` Key                  |
+| OrcaRouter（浏览器登录）         | `https://api.orcarouter.ai/v1` | `orcarouter_oauth` | 登录后由 OrcaRouter 签发 Key          |
 
 这个项目现在做了更稳的解析和回退处理，**对 OpenAI 兼容接口更友好**。如果 SDK 路径不顺，它也会尽量走更直接的 HTTP 路径，减少“能调通 API 但程序不工作”的情况。
+
+### OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) 是 OpenAI 兼容的 AI 网关：模型与 Agent 共用一个入口，自带自适应路由、自动故障转移、零加价推理、可观测性、护栏与 Agent 工具治理。接口是 OpenAI 线格式，因此接的是既有传输层，**不动调参循环，也不动 PID 安全逻辑**。
+
+**两种认证方式互相独立**，按机器情况任选：
+
+```bash
+# 1. 你已经有 Key（sk-orca-…）
+python tuner.py --orcarouter-key sk-orca-your-key
+
+# 2. 浏览器登录，由 OrcaRouter 签发一个（OAuth 2.0 + PKCE）
+python tuner.py --orcarouter-login
+
+# 没有浏览器（SSH / 容器 / CI）：改用回显验证码
+python tuner.py --orcarouter-login --orcarouter-flow B
+
+# 查看或清除已保存的凭据（不会打印完整 Key）
+python tuner.py --orcarouter-status
+python tuner.py --orcarouter-logout
+```
+
+两种方式得到的 Key 都存放在**项目原有的密钥位置**（`config.json`，或 `ORCAROUTER_API_KEY` 环境变量），并自动切换好 provider，不新增第二个凭据库。
+
+想用页面操作：`python tuner.py --orcarouter-settings` 会在本机回环地址上打开设置页，可以粘贴/清除 Key、发起登录，并从实时目录里选模型。
+
+#### 认证方式
+
+| 方式 | `LLM_PROVIDER` | Key 的来源 |
+| :--- | :------------- | :--------- |
+| API Key | `orcarouter` | 你自己粘贴已有的 `sk-orca-…` |
+| 浏览器登录 | `orcarouter_oauth` | 浏览器授权后由 OrcaRouter 签发 |
+
+登录使用 OAuth 2.0 + PKCE（`S256`）：每次尝试都会新生成 verifier，且它**不会离开本进程**，所以即使授权码被截获也无法被别人兑换。不需要 client secret，也不需要预注册回调地址。默认 `--orcarouter-flow A` 会在 `127.0.0.1` 上临时监听并自动接收回调；`--orcarouter-flow B` 则把验证码显示出来由你粘贴回去，适合无图形界面的机器。
+
+**签发的 Key 是长期凭据，不是 refresh token。** OrcaRouter 返回的是属于你账号的普通 API Key：计入你的账单、在控制台可见、随时可在[已授权应用](https://www.orcarouter.ai/console/authorized-apps)一键撤销。程序会一直复用它直到被撤销，**不会每次启动都重新授权，也不会伪造 refresh 授权**。若网关返回 `401`，该凭据会被标记为 `needs_reauth`，重新登录即可。（同一用户每 24 小时最多签发 10 个 PKCE Key。）
+
+#### 配置
+
+```json
+{
+  "LLM_PROVIDER": "orcarouter",
+  "ORCAROUTER_API_KEY": "sk-orca-...",
+  "LLM_MODEL_NAME": "orcarouter/auto"
+}
+```
+
+`ORCAROUTER_BASE_URL` 用于自建部署的共享地址；`ORCAROUTER_AUTH_BASE_URL` 与 `ORCAROUTER_API_BASE_URL` 可分别覆盖认证与推理地址，且优先级更高。认证走 `https://www.orcarouter.ai`，推理与模型目录走 `https://api.orcarouter.ai/v1`。非回环地址强制 HTTPS，仅回环开发允许 HTTP。
+
+#### 模型
+
+模型 ID 保留厂商命名空间（`openai/gpt-5.5`、`anthropic/claude-opus-4.8` 等）。模型列表来自实时目录 `GET https://api.orcarouter.ai/v1/models`，按能力过滤并在本次会话内缓存；目录不可用时会回退到一份经过核对的小型列表并**明确标注为降级状态**，而不是让你手填一个可能不存在的模型名。
+
+`python doctor.py` 会用同一个 `/models` 端点做连通性检查。
 
 ---
 

--- a/config.example.json
+++ b/config.example.json
@@ -6,6 +6,16 @@
     "LLM_API_BASE_URL": "https://api.openai.com/v1",
     "LLM_MODEL_NAME": "gpt-4o",
     "LLM_PROVIDER": "openai",
+    "ORCAROUTER_API_KEY": "",
+    "ORCAROUTER_AUTH_METHOD": "",
+    "ORCAROUTER_SCOPE": "",
+    "ORCAROUTER_AUTH_STATE": "ok",
+    "ORCAROUTER_CREDENTIAL_GENERATION": 0,
+    "ORCAROUTER_AUTH_FLOW": "A",
+    "ORCAROUTER_MODEL_CATALOG": [],
+    "ORCAROUTER_BASE_URL": "",
+    "ORCAROUTER_AUTH_BASE_URL": "",
+    "ORCAROUTER_API_BASE_URL": "",
     "HTTP_PROXY": "",
     "HTTPS_PROXY": "",
     "ALL_PROXY": "",
@@ -33,19 +43,55 @@
     "MATLAB_SETPOINT": 200.0,
     "PID_LIMITS": {
         "default": {
-            "p": {"min": 0.0, "max": 1000.0, "max_increase_ratio": 3.0},
-            "i": {"min": 0.0, "max": 250.0, "max_increase_ratio": 4.0},
-            "d": {"min": 0.0, "max": 250.0, "max_increase_ratio": 4.0}
+            "p": {
+                "min": 0.0,
+                "max": 1000.0,
+                "max_increase_ratio": 3.0
+            },
+            "i": {
+                "min": 0.0,
+                "max": 250.0,
+                "max_increase_ratio": 4.0
+            },
+            "d": {
+                "min": 0.0,
+                "max": 250.0,
+                "max_increase_ratio": 4.0
+            }
         },
         "python_sim": {
-            "p": {"min": 0.0, "max": 5000.0, "max_increase_ratio": 3.0},
-            "i": {"min": 0.0, "max": 500.0, "max_increase_ratio": 4.0},
-            "d": {"min": 0.0, "max": 500.0, "max_increase_ratio": 4.0}
+            "p": {
+                "min": 0.0,
+                "max": 5000.0,
+                "max_increase_ratio": 3.0
+            },
+            "i": {
+                "min": 0.0,
+                "max": 500.0,
+                "max_increase_ratio": 4.0
+            },
+            "d": {
+                "min": 0.0,
+                "max": 500.0,
+                "max_increase_ratio": 4.0
+            }
         },
         "simulink": {
-            "p": {"min": 0.0, "max": 5000.0, "max_increase_ratio": 5.0},
-            "i": {"min": 0.0, "max": 500.0, "max_increase_ratio": 6.0},
-            "d": {"min": 0.0, "max": 500.0, "max_increase_ratio": 6.0}
+            "p": {
+                "min": 0.0,
+                "max": 5000.0,
+                "max_increase_ratio": 5.0
+            },
+            "i": {
+                "min": 0.0,
+                "max": 500.0,
+                "max_increase_ratio": 6.0
+            },
+            "d": {
+                "min": 0.0,
+                "max": 500.0,
+                "max_increase_ratio": 6.0
+            }
         }
     },
     "PID_MAX_INCREASE_RATIO": 0.0

--- a/core/config.py
+++ b/core/config.py
@@ -77,6 +77,20 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "LLM_API_BASE_URL"              : "https://api.openai.com/v1",
     "LLM_MODEL_NAME"                : "gpt-4o",
     "LLM_PROVIDER"                  : "openai",
+    # OrcaRouter provider.  The API key is stored wherever every other
+    # provider secret is stored (this file / the matching env var) - no
+    # second secret store is introduced for it.  ORCAROUTER_AUTH_METHOD
+    # records which of the two entry points produced the current key.
+    "ORCAROUTER_API_KEY"            : "",
+    "ORCAROUTER_AUTH_METHOD"        : "",
+    "ORCAROUTER_SCOPE"              : "",
+    "ORCAROUTER_AUTH_STATE"         : "ok",
+    "ORCAROUTER_CREDENTIAL_GENERATION": 0,
+    "ORCAROUTER_AUTH_FLOW"          : "A",
+    "ORCAROUTER_MODEL_CATALOG"      : [],
+    "ORCAROUTER_BASE_URL"           : "",
+    "ORCAROUTER_AUTH_BASE_URL"      : "",
+    "ORCAROUTER_API_BASE_URL"       : "",
     "HTTP_PROXY"                    : "",
     "HTTPS_PROXY"                   : "",
     "ALL_PROXY"                     : "",
@@ -164,6 +178,22 @@ def load_config(create_if_missing: bool = True, verbose: bool = True) -> None:
         except Exception:
             if verbose:
                 print(f"[WARN] 环境变量 {key} 值无效，已忽略。")
+
+
+def save_config(verbose: bool = False) -> bool:
+    """Write the current CONFIG back to CONFIG_PATH.
+
+    Used by the OrcaRouter credential seam to persist a newly issued key in
+    the same place every other provider secret already lives.
+    """
+    try:
+        with open(CONFIG_PATH, "w", encoding="utf-8") as handle:
+            json.dump(CONFIG, handle, indent=4, ensure_ascii=False)
+        return True
+    except Exception as exc:
+        if verbose:
+            print(f"[WARN] 无法写入配置文件: {exc}")
+        return False
 
 
 def _apply_proxy_env_from_config() -> None:

--- a/core/doctoring.py
+++ b/core/doctoring.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 from typing import Any, Callable, Iterable, Mapping
 
 from core.compat import slotted_dataclass
+from llm.orcarouter import (
+    effective_api_key,
+    is_orcarouter_provider,
+    resolve_origins,
+)
 from sim.simulink_paths import (
     normalize_simulink_block_path,
     normalize_simulink_block_paths,
@@ -41,6 +46,14 @@ def models_endpoint(
                 "x-api-key": api_key,
                 "anthropic-version": "2023-06-01",
             },
+        )
+
+    if is_orcarouter_provider(normalized_provider):
+        # Discovery uses the inference origin's /v1, never the auth origin.
+        origins = resolve_origins({}, shared_base=normalized_base_url or None)
+        return (
+            f"{origins.api_base}/models",
+            {"Authorization": f"Bearer {api_key}"},
         )
 
     return (
@@ -211,6 +224,16 @@ def collect_doctor_checks(
         )
     )
 
+    # The OrcaRouter key has its own slot, so the generic placeholder check
+    # must not fire for a user who selected the OrcaRouter provider.
+    orcarouter_selected = is_orcarouter_provider(config.get("LLM_PROVIDER"))
+    effective_key = (
+        effective_api_key(config)
+        if orcarouter_selected
+        else str(config.get("LLM_API_KEY", "") or "")
+    )
+    configured_key = effective_key or str(config.get("LLM_API_KEY", "") or "")
+
     required_fields = (
         "LLM_API_KEY",
         "LLM_API_BASE_URL",
@@ -218,7 +241,11 @@ def collect_doctor_checks(
         "LLM_PROVIDER",
     )
     missing = [field for field in required_fields if not config.get(field)]
-    placeholder_key = str(config.get("LLM_API_KEY", "")) == "your-api-key-here"
+    if orcarouter_selected and not config.get("LLM_API_KEY"):
+        missing = [field for field in missing if field != "LLM_API_KEY"]
+    placeholder_key = configured_key == "your-api-key-here" or (
+        orcarouter_selected and not effective_key
+    )
     if missing or placeholder_key:
         detail: list[str] = []
         if missing:
@@ -245,13 +272,22 @@ def collect_doctor_checks(
                 (
                     f"{tr_fn('提供商', 'provider')}={config.get('LLM_PROVIDER')} "
                     f"{tr_fn('模型', 'model')}={config.get('LLM_MODEL_NAME')} "
-                    f"api_key={mask_secret(str(config.get('LLM_API_KEY', '')))}"
+                    f"api_key={mask_secret(configured_key)}"
+                    + (
+                        f" auth_method={config.get('ORCAROUTER_AUTH_METHOD') or 'api_key'}"
+                        if orcarouter_selected
+                        else ""
+                    )
                 ),
             )
         )
 
     base_url = str(config.get("LLM_API_BASE_URL", "")).strip()
     provider = str(config.get("LLM_PROVIDER", "openai")).strip()
+    if is_orcarouter_provider(provider):
+        # OrcaRouter's inference origin is a fixed public default; the user
+        # is not required to also fill in LLM_API_BASE_URL.
+        base_url = str(config.get("ORCAROUTER_API_BASE_URL", "") or "").strip()
     if not base_url:
         checks.append(
             DoctorCheck(
@@ -264,7 +300,7 @@ def collect_doctor_checks(
         endpoint, headers = models_endpoint(
             provider,
             base_url,
-            str(config.get("LLM_API_KEY", "")),
+            configured_key,
         )
         try:
             response = requests_get(endpoint, headers=headers, timeout=5)

--- a/docs/en-US/README.md
+++ b/docs/en-US/README.md
@@ -282,8 +282,95 @@ If you want to save real-time data during the tuning process (timestamp, setpoin
 | Ollama                          | `http://localhost:11434/v1` | `openai`        |
 | LM Studio                       | `http://localhost:1234/v1`  | `openai`        |
 | Anthropic Claude                | `https://api.anthropic.com` | `anthropic`     |
+| OrcaRouter (API key)            | `https://api.orcarouter.ai/v1` | `orcarouter` |
+| OrcaRouter (sign in)            | `https://api.orcarouter.ai/v1` | `orcarouter_oauth` |
 
 The current runtime is hardened for OpenAI-compatible endpoints and includes a more direct HTTP fallback path when SDK behavior is not enough.
+
+### OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway that
+runs one endpoint for models and agents, with adaptive routing, automatic
+failover, zero-markup inference, observability, guardrails and agent-tool
+governance. Because the wire format is OpenAI-compatible, it drops into the
+existing transport without touching the tuning loop or the PID safety layer.
+
+There are **two ways to authenticate**, and they are independent — use
+whichever fits your machine:
+
+```bash
+# 1. You already hold a key (sk-orca-...)
+python tuner.py --orcarouter-key sk-orca-your-key
+
+# 2. Sign in and let OrcaRouter issue one (OAuth 2.0 + PKCE, opens a browser)
+python tuner.py --orcarouter-login
+
+# No browser (SSH, container, CI)? Paste a code instead.
+python tuner.py --orcarouter-login --orcarouter-flow B
+
+# Review or remove the stored credential without printing the key
+python tuner.py --orcarouter-status
+python tuner.py --orcarouter-logout
+```
+
+Either way the key lands in the same place every other provider secret lives —
+`config.json`, or the `ORCAROUTER_API_KEY` environment variable — and the tool
+is switched to the matching provider for you. There is no second secret store.
+
+Prefer a page? `python tuner.py --orcarouter-settings` serves the provider
+settings on loopback so you can paste or clear a key, start the login, and pick
+a model from the live catalog.
+
+#### Authentication
+
+| Method | Provider value | Where the key comes from |
+| :----- | :------------- | :----------------------- |
+| API key | `orcarouter` | You paste an existing `sk-orca-…` key. |
+| Account login | `orcarouter_oauth` | A browser authorization issues one. |
+
+The login uses OAuth 2.0 with PKCE (`S256`): a fresh verifier is generated per
+attempt and never leaves the process, so an intercepted authorization code
+cannot be redeemed by anyone else. No client secret is involved and there is
+no redirect URI to register first. With `--orcarouter-flow A` (the default) a
+short-lived listener on `127.0.0.1` receives the code automatically; with
+`--orcarouter-flow B` the consent screen shows a code you paste back, which is
+what you want on a headless box.
+
+**The issued key is durable, not a refresh token.** OrcaRouter returns a normal
+API key that belongs to your account — it is billed to you, listed in your
+console, and revocable at any time from
+[your authorized apps](https://www.orcarouter.ai/console/authorized-apps). The
+tool reuses the stored key until OrcaRouter revokes it; it never re-authorizes
+on every launch and never fakes a refresh grant. If the gateway rejects a key
+with `401`, that credential is marked `needs_reauth` and you re-run the login.
+(The consent endpoint allows at most 10 PKCE-issued keys per user per 24 hours.)
+
+#### Configuration
+
+```json
+{
+  "LLM_PROVIDER": "orcarouter",
+  "ORCAROUTER_API_KEY": "sk-orca-...",
+  "LLM_MODEL_NAME": "orcarouter/auto"
+}
+```
+
+`ORCAROUTER_BASE_URL` sets a shared self-hosted base; `ORCAROUTER_AUTH_BASE_URL`
+and `ORCAROUTER_API_BASE_URL` override authentication and inference separately
+and take precedence. Authentication uses `https://www.orcarouter.ai`; inference
+and model discovery use `https://api.orcarouter.ai/v1`. Remote origins must be
+HTTPS — plain HTTP is accepted only for loopback development.
+
+#### Models
+
+Model IDs keep their vendor namespace (`openai/gpt-5.5`,
+`anthropic/claude-opus-4.8`, …). The model list is read from the live catalog
+at `GET https://api.orcarouter.ai/v1/models`, filtered per capability, and
+cached for the current session. When discovery is unavailable the tool falls
+back to a small verified catalog and shows that it is degraded, rather than
+letting you type a model name that might not exist.
+
+`python doctor.py` checks reachability against the same `/models` endpoint.
 
 ---
 

--- a/llm/client.py
+++ b/llm/client.py
@@ -11,6 +11,7 @@ import traceback
 from typing import Any, Callable, Dict, List, Optional
 
 from core.console import append_console_log
+from llm import orcarouter
 from llm.prompts import SYSTEM_PROMPT, build_user_prompt, get_system_prompt
 from llm.response_parser import parse_json_response
 from llm.stream_formatter import JSONStreamFormatter
@@ -35,6 +36,13 @@ class LLMTuner:
         self.base_url = (base_url or "").rstrip("/")
         self.model = model
         self.provider_choice = self._normalize_provider_choice(provider)
+        # OrcaRouter is a first-class provider: resolve its origins and
+        # credential from the single credential seam before transport
+        # selection, then reuse the unchanged OpenAI-compatible transport.
+        self.orcarouter: Optional[orcarouter.OrcaRouterCredential] = None
+        self.orcarouter_origins: Optional[orcarouter.OrcaRouterOrigins] = None
+        if orcarouter.is_orcarouter_provider(self.provider_choice):
+            self._configure_orcarouter()
         self.provider = self._resolve_transport()
         self.timeout = timeout
         self.debug_output = debug_output
@@ -48,6 +56,40 @@ class LLMTuner:
         self.use_sdk = isinstance(self.llm_client, (OpenAISDKProvider, AnthropicSDKProvider))
         self.client = getattr(self.llm_client, "client", None)
         self.requests = getattr(self.llm_client, "requests", None)
+
+    def _configure_orcarouter(self) -> None:
+        """Point the provider at OrcaRouter's origins and credential.
+
+        Both authentication choices (a pasted API key and the PKCE login)
+        produce the same credential shape, so nothing below this line needs
+        to know which one was used.
+        """
+        from core.config import CONFIG
+
+        origins = orcarouter.resolve_origins(CONFIG)
+        self.orcarouter_origins = origins
+        record = orcarouter.resolve_credential(CONFIG, explicit_key=self.api_key)
+        if not record.is_set:
+            raise orcarouter.OrcaRouterError(
+                "OrcaRouter is selected but no API key is configured. "
+                "Paste one into ORCAROUTER_API_KEY, or run "
+                "`python tuner.py --orcarouter-login` to authorize in a browser."
+            )
+        if record.state == orcarouter.REAUTH_NEEDED:
+            raise orcarouter.OrcaRouterError(
+                "The stored OrcaRouter key was rejected by the gateway. "
+                "Run `python tuner.py --orcarouter-login` to issue a new one."
+            )
+        self.orcarouter = orcarouter.OrcaRouterCredential(
+            api_key=record.api_key,
+            source=record.source or "api_key",
+            generation=record.generation,
+            scope=record.scope or orcarouter.REQUESTED_SCOPE,
+        )
+        self.api_key = record.api_key
+        # Inference always uses the API origin, never the auth origin.
+        self.base_url = origins.api_base
+        self.provider_choice = "openai"
 
     def _initialize_provider(self) -> BaseLLMProvider:
         try:

--- a/llm/orcarouter.py
+++ b/llm/orcarouter.py
@@ -1,0 +1,1384 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+llm/orcarouter.py - OrcaRouter as a first-class provider.
+
+OrcaRouter is an OpenAI-compatible AI gateway that exposes one endpoint for
+chat/reasoning models and agents (routing, failover, observability,
+guardrails).  Inference uses the OpenAI wire format, so the tuning loop keeps
+speaking the existing OpenAI-compatible transport and nothing in the tuning or
+safety path changes.
+
+This module owns the three pieces the provider needs:
+
+* **Origins** - authentication lives on ``https://www.orcarouter.ai`` while
+  inference and model discovery live on ``https://api.orcarouter.ai/v1``.
+  They are separate public origins and neither is derived from the other.
+* **Credentials** - one small seam (:class:`CredentialSource`) with two
+  adapters: a pasted API key and an OAuth 2.0 + PKCE login.  Both yield the
+  same :class:`OrcaRouterCredential`, so the transport and the model catalog
+  never need to know which one the user picked.
+* **Model catalog** - capability-filtered discovery from
+  ``GET {api_base}/models`` plus a small verified cold-start seed.
+
+The key belongs to the user: it is billed to their OrcaRouter account and
+revocable by them at any time.  It is never logged, printed, or sent to the
+browser.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import socket
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import webbrowser
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple
+
+# The app label shown on the OrcaRouter consent screen.  It is a claim the
+# screen presents to the user, so it names this project rather than a brand.
+APP_NAME = "LLM PID Tuner"
+
+PROVIDER_ID = "orcarouter"
+PROVIDER_ID_PKCE = "orcarouter_oauth"
+
+# Public defaults.  Authentication and inference are different origins; never
+# derive one from the other by swapping a hostname or appending "/v1".
+DEFAULT_AUTH_BASE = "https://www.orcarouter.ai"
+DEFAULT_API_BASE = "https://api.orcarouter.ai/v1"
+
+# Fixed paths.  The relay is on api.orcarouter.ai at /v1; the auth endpoints
+# are on www.orcarouter.ai under /api/v1/auth.  A /v1/auth/keys path 404s.
+AUTHORIZE_PATH = "/auth"
+EXCHANGE_PATH = "/api/v1/auth/keys"
+DEVICE_CODE_PATH = "/api/v1/auth/device/code"
+DEVICE_TOKEN_PATH = "/api/v1/auth/device/token"
+MODELS_PATH = "/models"
+
+# Environment variables, in the project's existing env-over-config idiom.
+ENV_SHARED_BASE = "ORCA_BASE_URL"
+ENV_AUTH_BASE = "ORCA_AUTH_BASE_URL"
+ENV_API_BASE = "ORCA_API_BASE_URL"
+
+# The scope this client asks for.  "connector" is refused on the way in for a
+# client that cannot use it, so ask for the one we can actually hold.
+REQUESTED_SCOPE = "api"
+ACCEPTED_SCOPES = ("api",)
+
+# Bounds so a hostile or broken catalog cannot consume unbounded memory.
+CATALOG_TIMEOUT = 10.0
+CATALOG_MAX_BYTES = 4 * 1024 * 1024
+CATALOG_MAX_ITEMS = 1000
+
+# A reauth marker.  A durable OrcaRouter key is not a refresh token: there is
+# no refresh grant, so a 401 means "re-run the connect flow".
+REAUTH_NEEDED = "needs_reauth"
+REAUTH_OK = "ok"
+
+_KEY_PREFIX = "sk-orca-"
+
+
+class OrcaRouterError(RuntimeError):
+    """Base class for OrcaRouter provider failures."""
+
+
+class OrcaRouterAuthError(OrcaRouterError):
+    """The upstream rejected the credential (HTTP 401).
+
+    Terminal: it marks the credential generation ``needs_reauth``.  There is
+    no refresh grant to attempt.
+    """
+
+    def __init__(self, message: str, *, generation: int = -1, account: str = ""):
+        super().__init__(message)
+        self.generation = generation
+        self.account = account
+
+
+class OrcaRouterPKCEError(OrcaRouterError):
+    """The PKCE authorization could not be completed."""
+
+
+# ---------------------------------------------------------------------------
+# Origins
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class OrcaRouterOrigins:
+    """Resolved auth/inference origins.
+
+    Explicit overrides win; ``ORCA_BASE_URL`` is a shared self-hosted
+    fallback for deployments that put both behind one name.  Remote origins
+    must be HTTPS - plain HTTP is only accepted for loopback development.
+    """
+
+    auth_base: str
+    api_base: str
+
+    @property
+    def authorize_url(self) -> str:
+        return f"{self.auth_base}{AUTHORIZE_PATH}"
+
+    @property
+    def exchange_url(self) -> str:
+        return f"{self.auth_base}{EXCHANGE_PATH}"
+
+    @property
+    def models_url(self) -> str:
+        return f"{self.api_base}{MODELS_PATH}"
+
+
+def _strip_slash(value: str) -> str:
+    return (value or "").strip().rstrip("/")
+
+
+def _is_loopback(host: str) -> bool:
+    return host in {"localhost", "127.0.0.1", "::1", "[::1]"}
+
+
+def validate_origin(url: str, *, what: str) -> str:
+    """Return a normalized origin, rejecting insecure remote schemes."""
+    normalized = _strip_slash(url)
+    if not normalized:
+        raise OrcaRouterError(f"{what} base URL is empty")
+    parsed = urllib.parse.urlsplit(normalized)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise OrcaRouterError(f"{what} base URL is not an absolute http(s) URL")
+    if parsed.scheme == "http" and not _is_loopback(parsed.hostname):
+        raise OrcaRouterError(
+            f"{what} base URL must use HTTPS for a non-loopback host"
+        )
+    return normalized
+
+
+def resolve_origins(
+    config: Optional[Dict[str, Any]] = None,
+    *,
+    environ: Optional[Dict[str, str]] = None,
+    shared_base: Optional[str] = None,
+    auth_base: Optional[str] = None,
+    api_base: Optional[str] = None,
+) -> OrcaRouterOrigins:
+    """Resolve the auth and inference origins with explicit wins.
+
+    Precedence, highest first: explicit argument, dedicated environment
+    variable, dedicated config key, then the shared base (argument, env, or
+    config) for whichever origin was not set, then the public default.
+    """
+    env = os.environ if environ is None else environ
+    cfg = config if config is not None else {}
+
+    def pick(arg: Optional[str], env_key: str, cfg_key: str) -> Optional[str]:
+        for candidate in (arg, env.get(env_key), cfg.get(cfg_key)):
+            value = _strip_slash(candidate) if isinstance(candidate, str) else ""
+            if value:
+                return value
+        return None
+
+    shared = pick(shared_base, ENV_SHARED_BASE, "ORCAROUTER_BASE_URL")
+    resolved_auth = pick(auth_base, ENV_AUTH_BASE, "ORCAROUTER_AUTH_BASE_URL")
+    resolved_api = pick(api_base, ENV_API_BASE, "ORCAROUTER_API_BASE_URL")
+
+    auth = resolved_auth or shared or DEFAULT_AUTH_BASE
+    api = resolved_api or shared or DEFAULT_API_BASE
+
+    auth = validate_origin(auth, what="OrcaRouter auth")
+    api = validate_origin(api, what="OrcaRouter inference")
+    if not api.rstrip("/").endswith("/v1"):
+        # The relay is served under /v1.  Append it only to the API origin we
+        # were handed - never to derive it from the auth origin.
+        api = f"{api}/v1"
+    return OrcaRouterOrigins(auth_base=auth, api_base=api)
+
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+
+def redact_secret(value: str) -> str:
+    """Mirror of ``core.doctoring.mask_secret`` for rendering credentials.
+
+    Kept local so the auth module has no import cycle with the doctor.
+    """
+    if not value:
+        return "<empty>"
+    if len(value) <= 8:
+        return "*" * len(value)
+    return f"{value[:4]}...{value[-4:]}"
+
+
+def scrub(text: str, *secrets_to_hide: str) -> str:
+    """Remove known secret values from a message before it is shown or logged."""
+    scrubbed = str(text)
+    for secret in secrets_to_hide:
+        if secret and len(secret) >= 8:
+            scrubbed = scrubbed.replace(secret, "<redacted>")
+    return scrubbed
+
+
+# ---------------------------------------------------------------------------
+# PKCE
+# ---------------------------------------------------------------------------
+
+def b64url(raw: bytes) -> str:
+    """base64url without padding, as the challenge encoding requires."""
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+@dataclass(frozen=True)
+class PKCEPair:
+    """A verifier and its S256 challenge.
+
+    The verifier never leaves the process: it is not logged, not serialized,
+    and never placed on the authorize URL.
+    """
+
+    verifier: str
+    challenge: str
+    state: str
+
+    def __repr__(self) -> str:  # pragma: no cover - defensive
+        return f"PKCEPair(challenge={self.challenge!r}, state={self.state!r})"
+
+    __str__ = __repr__
+
+
+def new_pkce_pair(randbytes: Callable[[int], bytes] = secrets.token_bytes) -> PKCEPair:
+    """Fresh verifier/state from a cryptographic RNG for every attempt."""
+    verifier = b64url(randbytes(32))
+    challenge = b64url(hashlib.sha256(verifier.encode("ascii")).digest())
+    state = b64url(randbytes(16))
+    return PKCEPair(verifier=verifier, challenge=challenge, state=state)
+
+
+def build_authorize_url(
+    origins: OrcaRouterOrigins,
+    pair: PKCEPair,
+    *,
+    callback_url: str,
+    app_name: str = APP_NAME,
+    scope: str = REQUESTED_SCOPE,
+    login_hint: Optional[str] = None,
+    workspace_hint: Optional[str] = None,
+    prompt: Optional[str] = None,
+) -> str:
+    """Build the consent URL.  S256 is always sent.
+
+    ``callback_url=oob`` is Flow B; anything else is a Flow A loopback URL.
+    The verifier is deliberately absent from this URL - only its hash travels.
+    """
+    params = {
+        "callback_url": callback_url,
+        "code_challenge": pair.challenge,
+        "code_challenge_method": "S256",
+        "state": pair.state,
+        "app_name": app_name,
+    }
+    if scope:
+        params["scope"] = scope
+    if login_hint:
+        params["login_hint"] = login_hint
+    if workspace_hint:
+        params["workspace_hint"] = workspace_hint
+    if prompt:
+        params["prompt"] = prompt
+    return f"{origins.authorize_url}?{urllib.parse.urlencode(params)}"
+
+
+def validate_callback_url(callback_url: str) -> str:
+    """Apply OrcaRouter's callback_url rules before opening a browser."""
+    if callback_url == "oob":
+        return callback_url
+    parsed = urllib.parse.urlsplit(callback_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise OrcaRouterPKCEError("callback_url must be an absolute http(s) URL or 'oob'")
+    if parsed.scheme == "http" and not _is_loopback(parsed.hostname):
+        raise OrcaRouterPKCEError(
+            "http callback_url is only allowed on localhost, 127.0.0.1 or [::1]"
+        )
+    if parsed.username or parsed.password or parsed.fragment:
+        raise OrcaRouterPKCEError("callback_url must not carry userinfo or a fragment")
+    return callback_url
+
+
+def callback_url_matches_origins(callback_url: str, origins: OrcaRouterOrigins) -> bool:
+    """Reject a callback that points back at the OrcaRouter auth origin."""
+    if callback_url == "oob":
+        return True
+    return not callback_url.startswith(origins.auth_base)
+
+
+@dataclass(frozen=True)
+class ExchangeResult:
+    """What the exchange actually granted - not what we asked for."""
+
+    key: str
+    scope: str
+    user_id: str
+
+    @property
+    def scope_is_usable(self) -> bool:
+        return self.scope in ACCEPTED_SCOPES
+
+
+def _scope_warning(result: ExchangeResult) -> Optional[str]:
+    if result.scope_is_usable:
+        return None
+    return (
+        f'OrcaRouter granted scope "{result.scope}", not "{REQUESTED_SCOPE}". '
+        "This client needs an api-scope key; ask a workspace owner to approve "
+        "the wider grant, then connect again."
+    )
+
+
+def _post_json(
+    url: str,
+    payload: Dict[str, Any],
+    *,
+    timeout: float,
+    opener: Optional[Callable[..., Any]] = None,
+) -> Tuple[int, Dict[str, Any]]:
+    """POST JSON and return (status, parsed body) without raising on 4xx."""
+    body = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+    open_fn = urllib.request.urlopen if opener is None else opener
+    try:
+        with open_fn(request, timeout=timeout) as response:
+            raw = response.read(CATALOG_MAX_BYTES)
+            status = getattr(response, "status", 200)
+    except urllib.error.HTTPError as exc:
+        raw = exc.read(CATALOG_MAX_BYTES) if hasattr(exc, "read") else b""
+        status = exc.code
+    try:
+        parsed = json.loads(raw.decode("utf-8")) if raw else {}
+    except (ValueError, UnicodeDecodeError):
+        parsed = {}
+    if not isinstance(parsed, dict):
+        parsed = {}
+    return status, parsed
+
+
+def exchange_code(
+    origins: OrcaRouterOrigins,
+    pair: PKCEPair,
+    code: str,
+    *,
+    timeout: float = 30.0,
+    opener: Optional[Callable[..., Any]] = None,
+) -> ExchangeResult:
+    """Redeem an auth code for an OrcaRouter API key.
+
+    Always posts to the auth origin's ``/api/v1/auth/keys``; the inference
+    origin is never used for credential exchange.  Error responses are mapped
+    to actionable messages without echoing the verifier or the code.
+    """
+    if not code or not code.strip():
+        raise OrcaRouterPKCEError("No authorization code was provided.")
+
+    status, payload = _post_json(
+        origins.exchange_url,
+        {
+            "code": code.strip(),
+            "code_verifier": pair.verifier,
+            "code_challenge_method": "S256",
+        },
+        timeout=timeout,
+        opener=opener,
+    )
+
+    if status == 200:
+        key = str(payload.get("key", "") or "")
+        if not key:
+            raise OrcaRouterPKCEError(
+                "OrcaRouter returned no key. Connect again from the settings panel."
+            )
+        return ExchangeResult(
+            key=key,
+            scope=str(payload.get("scope", "") or ""),
+            user_id=str(payload.get("user_id", "") or ""),
+        )
+    if status == 400:
+        raise OrcaRouterPKCEError(
+            "OrcaRouter rejected the PKCE challenge method. Reconnect from the "
+            "settings panel to start a fresh authorization."
+        )
+    if status == 403:
+        raise OrcaRouterPKCEError(
+            "This authorization code is unknown, expired, or already used. "
+            "Codes are single-use with a 10 minute lifetime - start a new login."
+        )
+    if status == 429:
+        raise OrcaRouterPKCEError(
+            "OrcaRouter rate-limited this login with HTTP 429: a user may hold "
+            "at most 10 PKCE-issued keys per 24 hours. Reuse the stored key, "
+            "or try again later."
+        )
+    raise OrcaRouterPKCEError(
+        f"OrcaRouter login failed with HTTP {status}. "
+        "Check your network and try again."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Flow A - loopback redirect listener
+# ---------------------------------------------------------------------------
+
+_CALLBACK_PAGE = (
+    "<!doctype html><meta charset='utf-8'>"
+    "<title>OrcaRouter</title>"
+    "<body style='font-family:system-ui;padding:3rem'>"
+    "<h2>{heading}</h2><p>{detail}</p></body>"
+)
+
+
+@dataclass
+class LoopbackCallback:
+    """A one-shot listener on 127.0.0.1 that receives the redirect."""
+
+    callback_url: str
+    wait: Callable[[float], Optional[Tuple[Optional[str], Optional[str]]]]
+    close: Callable[[], None]
+
+
+def start_loopback_listener(
+    state: str,
+    *,
+    timeout: float = 300.0,
+    host: str = "127.0.0.1",
+    path: str = "/cb",
+) -> LoopbackCallback:
+    """Open the listener *before* the browser so the port is known.
+
+    Returns a handle whose ``wait`` blocks until the browser comes back,
+    the user denies, or the window closes.  The state is compared with
+    :func:`hmac.compare_digest` before the code is trusted.
+    """
+    received: Dict[str, Any] = {}
+    done = threading.Event()
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind((host, 0))
+    server.listen(1)
+    port = server.getsockname()[1]
+    server.settimeout(1.0)
+
+    def serve() -> None:
+        deadline = time.time() + timeout
+        while time.time() < deadline and not done.is_set():
+            try:
+                conn, _ = server.accept()
+            except (socket.timeout, OSError):
+                continue
+            try:
+                raw = conn.recv(8192).decode("latin-1")
+                request_line = raw.split("\r\n", 1)[0]
+                parts = request_line.split(" ")
+                target = parts[1] if len(parts) > 1 else "/"
+                parsed = urllib.parse.urlsplit(target)
+                query = urllib.parse.parse_qs(parsed.query)
+                if parsed.path != path:
+                    conn.sendall(
+                        b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n"
+                    )
+                    conn.close()
+                    continue
+
+                got_state = (query.get("state") or [""])[0]
+                if not hmac.compare_digest(str(got_state), str(state)):
+                    received["error"] = "state mismatch"
+                else:
+                    error = (query.get("error") or [""])[0]
+                    if error:
+                        received["error"] = error
+                    else:
+                        received["code"] = (query.get("code") or [""])[0]
+                # Always answer the browser: never leave a blank window.
+                page = _CALLBACK_PAGE.format(
+                    heading="OrcaRouter connected"
+                    if "code" in received
+                    else "OrcaRouter authorization not completed",
+                    detail="You can close this tab and return to the tuner.",
+                ).encode("utf-8")
+                conn.sendall(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\n"
+                    b"Content-Length: " + str(len(page)).encode() + b"\r\n\r\n" + page
+                )
+                conn.close()
+            except OSError:
+                pass
+            done.set()
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+
+    def wait(wait_timeout: float = timeout) -> Optional[Tuple[Optional[str], Optional[str]]]:
+        if not done.wait(wait_timeout):
+            return None
+        return received.get("code"), received.get("error")
+
+    def close() -> None:
+        done.set()
+        try:
+            server.close()
+        except OSError:
+            pass
+
+    return LoopbackCallback(
+        callback_url=f"http://{host}:{port}{path}", wait=wait, close=close
+    )
+
+
+# ---------------------------------------------------------------------------
+# Credentials
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class OrcaRouterCredential:
+    """The single credential shape both adapters produce.
+
+    Downstream code (transport, catalog, doctor) only ever sees this, so it
+    cannot tell - and must not care - which entry point produced it.
+    """
+
+    api_key: str
+    source: str
+    generation: int = 0
+    scope: str = REQUESTED_SCOPE
+    user_id: str = ""
+    obtained_at: float = 0.0
+
+    @property
+    def is_set(self) -> bool:
+        return bool(self.api_key)
+
+    def masked(self) -> str:
+        return redact_secret(self.api_key)
+
+
+class CredentialSource(ABC):
+    """The seam: obtain-or-read a credential.
+
+    ``ApiKeyCredentialSource`` and ``PKCESource`` are the two adapters.
+    Nothing else in the provider knows how a key was acquired.
+    """
+
+    source_id: str = ""
+
+    @abstractmethod
+    def acquire(
+        self, *, on_hint: Optional[Callable[[str], None]] = None
+    ) -> OrcaRouterCredential:
+        """Return a usable credential or raise :class:`OrcaRouterError`."""
+
+
+@dataclass
+class ApiKeyCredentialSource(CredentialSource):
+    """Adapter 1: a key the user already holds and pasted in."""
+
+    api_key: str
+    generation: int = 0
+    source_id: str = field(default="api_key", init=False)
+
+    def acquire(
+        self, *, on_hint: Optional[Callable[[str], None]] = None
+    ) -> OrcaRouterCredential:
+        key = (self.api_key or "").strip()
+        if not key:
+            raise OrcaRouterError(
+                "No OrcaRouter API key set. Paste a key from "
+                "https://www.orcarouter.ai/console or use the login button."
+            )
+        if not key.startswith(_KEY_PREFIX):
+            # A format hint only.  An sk-orca- prefix is not proof of
+            # validity, so this is a warning rather than a rejection: the
+            # first real request establishes validity.
+            if on_hint:
+                on_hint(
+                    "This key does not start with 'sk-orca-'. "
+                    "OrcaRouter keys normally do - check for a copy/paste slip."
+                )
+        return OrcaRouterCredential(
+            api_key=key,
+            source=self.source_id,
+            generation=self.generation,
+            obtained_at=time.time(),
+        )
+
+
+@dataclass
+class PKCECredentialSource(CredentialSource):
+    """Adapter 2: OAuth 2.0 + PKCE login, which mints the same kind of key."""
+
+    origins: OrcaRouterOrigins
+    flow: str = "A"
+    open_browser: Callable[[str], Any] = webbrowser.open
+    prompt_for_code: Callable[[], str] = input
+    timeout: float = 300.0
+    generation: int = 0
+    source_id: str = field(default="pkce", init=False)
+
+    def acquire(
+        self, *, on_hint: Optional[Callable[[str], None]] = None
+    ) -> OrcaRouterCredential:
+        pair = new_pkce_pair()
+        if self.flow.upper() == "B":
+            code = self._authorize_oob(pair, on_hint)
+        else:
+            code = self._authorize_loopback(pair, on_hint)
+
+        result = exchange_code(self.origins, pair, code, timeout=self.timeout)
+        warning = _scope_warning(result)
+        if warning and on_hint:
+            on_hint(warning)
+        return OrcaRouterCredential(
+            api_key=result.key,
+            source=self.source_id,
+            generation=self.generation,
+            scope=result.scope,
+            user_id=result.user_id,
+            obtained_at=time.time(),
+        )
+
+    def _authorize_oob(
+        self, pair: PKCEPair, on_hint: Optional[Callable[[str], None]]
+    ) -> str:
+        """Flow B - the code is shown to the user and pasted back."""
+        validate_callback_url("oob")
+        url = build_authorize_url(self.origins, pair, callback_url="oob")
+        if on_hint:
+            on_hint(
+                "Open this URL, approve access, then paste the code OrcaRouter "
+                f"shows you:\n{url}"
+            )
+        try:
+            self.open_browser(url)
+        except Exception:
+            pass  # The URL was printed; a headless box simply skips this.
+        try:
+            code = str(self.prompt_for_code() or "").strip()
+        except EOFError as exc:
+            raise OrcaRouterPKCEError(
+                "No authorization code entered; the login was cancelled."
+            ) from exc
+        if not code:
+            raise OrcaRouterPKCEError("No authorization code entered; cancelled.")
+        return code
+
+    def _authorize_loopback(
+        self, pair: PKCEPair, on_hint: Optional[Callable[[str], None]]
+    ) -> str:
+        """Flow A - a loopback listener receives the redirect automatically."""
+        handle = start_loopback_listener(pair.state, timeout=self.timeout)
+        try:
+            callback = validate_callback_url(handle.callback_url)
+            if not callback_url_matches_origins(callback, self.origins):
+                raise OrcaRouterPKCEError(
+                    "Refusing to send the authorization code back to the "
+                    "OrcaRouter auth origin."
+                )
+            url = build_authorize_url(self.origins, pair, callback_url=callback)
+            if on_hint:
+                on_hint(f"Opening your browser to authorize with OrcaRouter:\n{url}")
+            try:
+                self.open_browser(url)
+            except Exception:
+                pass
+            outcome = handle.wait(self.timeout)
+        finally:
+            handle.close()
+
+        if outcome is None:
+            raise OrcaRouterPKCEError(
+                "The OrcaRouter login timed out before it was approved. "
+                "Start it again when you are ready."
+            )
+        code, error = outcome
+        if error:
+            raise OrcaRouterPKCEError(
+                f"The OrcaRouter login was not completed ({error})."
+            )
+        if not code:
+            raise OrcaRouterPKCEError("OrcaRouter returned no authorization code.")
+        return code
+
+
+# ---------------------------------------------------------------------------
+# Credential lifecycle
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CredentialRecord:
+    """Persisted credential plus the generation that produced it."""
+
+    api_key: str = ""
+    source: str = ""
+    scope: str = ""
+    generation: int = 0
+    state: str = REAUTH_OK
+
+    @property
+    def is_set(self) -> bool:
+        return bool(self.api_key)
+
+    def masked(self) -> str:
+        return redact_secret(self.api_key)
+
+
+class OrcaRouterCredentialStore:
+    """Credential lifecycle over the project's own config store.
+
+    The key lives where every other provider secret lives (``config.json``
+    and the matching environment variable).  No second secret store is
+    introduced.  A durable key is *not* a refresh token, so a 401 marks
+    exactly the generation that made the rejected request.
+    """
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None):
+        self._config = config
+
+    @property
+    def config(self) -> Dict[str, Any]:
+        if self._config is not None:
+            return self._config
+        from core.config import CONFIG
+
+        return CONFIG
+
+    # -- read -------------------------------------------------------------
+    def load(self) -> CredentialRecord:
+        cfg = self.config
+        return CredentialRecord(
+            api_key=str(cfg.get("ORCAROUTER_API_KEY", "") or "").strip(),
+            source=str(cfg.get("ORCAROUTER_AUTH_METHOD", "") or "").strip(),
+            scope=str(cfg.get("ORCAROUTER_SCOPE", "") or "").strip(),
+            generation=int(cfg.get("ORCAROUTER_CREDENTIAL_GENERATION", 0) or 0),
+            state=str(cfg.get("ORCAROUTER_AUTH_STATE", REAUTH_OK) or REAUTH_OK),
+        )
+
+    def credential(self) -> OrcaRouterCredential:
+        record = self.load()
+        return OrcaRouterCredential(
+            api_key=record.api_key,
+            source=record.source,
+            generation=record.generation,
+            scope=record.scope or REQUESTED_SCOPE,
+        )
+
+    # -- write ------------------------------------------------------------
+    def save(self, credential: OrcaRouterCredential) -> CredentialRecord:
+        """Persist a credential, bumping the generation.
+
+        Bumping on every successful write is what makes a late 401 from an
+        older request unable to mark the new credential broken.
+        """
+        cfg = self.config
+        record = self.load()
+        generation = record.generation + 1
+        cfg["ORCAROUTER_API_KEY"] = credential.api_key
+        cfg["ORCAROUTER_AUTH_METHOD"] = credential.source
+        cfg["ORCAROUTER_SCOPE"] = credential.scope
+        cfg["ORCAROUTER_AUTH_STATE"] = REAUTH_OK
+        cfg["ORCAROUTER_CREDENTIAL_GENERATION"] = generation
+        return CredentialRecord(
+            api_key=credential.api_key,
+            source=credential.source,
+            scope=credential.scope,
+            generation=generation,
+            state=REAUTH_OK,
+        )
+
+    def save_credential(
+        self, credential: OrcaRouterCredential, *, persist: Callable[..., Any]
+    ) -> CredentialRecord:
+        """Persist through a caller-supplied writer (the config file)."""
+        record = self.save(credential)
+        persist()
+        return record
+
+    def clear(self) -> CredentialRecord:
+        cfg = self.config
+        cfg["ORCAROUTER_API_KEY"] = ""
+        cfg["ORCAROUTER_AUTH_METHOD"] = ""
+        cfg["ORCAROUTER_SCOPE"] = ""
+        cfg["ORCAROUTER_AUTH_STATE"] = REAUTH_OK
+        cfg["ORCAROUTER_CREDENTIAL_GENERATION"] = (
+            int(cfg.get("ORCAROUTER_CREDENTIAL_GENERATION", 0) or 0) + 1
+        )
+        return self.load()
+
+    # -- upstream feedback ------------------------------------------------
+    def mark_needs_reauth(self, generation: int) -> bool:
+        """Mark the rejected generation ``needs_reauth``.
+
+        Returns True when the marker was applied.  A response from an older
+        generation is ignored so it cannot poison a freshly reauthorized key.
+        The stale secret is deliberately left in place - only a successful
+        new login replaces it.
+        """
+        cfg = self.config
+        current = int(cfg.get("ORCAROUTER_CREDENTIAL_GENERATION", 0) or 0)
+        if generation != current:
+            return False
+        cfg["ORCAROUTER_AUTH_STATE"] = REAUTH_NEEDED
+        return True
+
+    def is_terminal_reauth(self, generation: int) -> bool:
+        cfg = self.config
+        return (
+            str(cfg.get("ORCAROUTER_AUTH_STATE", REAUTH_OK)) == REAUTH_NEEDED
+            and int(cfg.get("ORCAROUTER_CREDENTIAL_GENERATION", 0) or 0) == generation
+        )
+
+
+def effective_api_key(config: Optional[Dict[str, Any]]) -> str:
+    """The OrcaRouter key for ``config``, falling back to the generic slot.
+
+    A user who set ``LLM_PROVIDER=orcarouter`` with ``LLM_API_KEY=sk-orca-...``
+    keeps working, but the dedicated key wins when both are present.
+    """
+    cfg = config if config is not None else {}
+    dedicated = str(cfg.get("ORCAROUTER_API_KEY", "") or "").strip()
+    if dedicated:
+        return dedicated
+    generic = str(cfg.get("LLM_API_KEY", "") or "").strip()
+    if generic and generic != "your-api-key-here" and generic.startswith(_KEY_PREFIX):
+        return generic
+    return ""
+
+
+def resolve_credential(
+    config: Optional[Dict[str, Any]] = None,
+    *,
+    explicit_key: str = "",
+) -> CredentialRecord:
+    """Read the stored credential without acquiring a new one."""
+    cfg = config if config is not None else {}
+    key = effective_api_key(cfg)
+    if not key:
+        candidate = str(explicit_key or "").strip()
+        if candidate and candidate != "your-api-key-here":
+            key = candidate
+    return CredentialRecord(
+        api_key=key,
+        source=str(cfg.get("ORCAROUTER_AUTH_METHOD", "") or "").strip(),
+        scope=str(cfg.get("ORCAROUTER_SCOPE", "") or "").strip(),
+        generation=int(cfg.get("ORCAROUTER_CREDENTIAL_GENERATION", 0) or 0),
+        state=str(cfg.get("ORCAROUTER_AUTH_STATE", REAUTH_OK) or REAUTH_OK),
+    )
+
+
+def build_credential_source(
+    method: str,
+    *,
+    config: Optional[Dict[str, Any]],
+    origins: OrcaRouterOrigins,
+) -> CredentialSource:
+    """Pick the adapter for ``method`` - the two entries on the same seam.
+
+    ``orcarouter`` (and any alias) yields the API-key adapter;
+    ``orcarouter_oauth`` yields the PKCE adapter.  Both return an
+    :class:`OrcaRouterCredential`.
+    """
+    normalized = normalize_orcarouter_method(method)
+    if normalized == PROVIDER_ID_PKCE:
+        return PKCECredentialSource(origins=origins)
+    cfg = config if config is not None else {}
+    return ApiKeyCredentialSource(
+        api_key=str(cfg.get("ORCAROUTER_API_KEY", "") or ""),
+        generation=int(cfg.get("ORCAROUTER_CREDENTIAL_GENERATION", 0) or 0),
+    )
+
+
+_API_KEY_ALIASES = {"orcarouter", "orca", "orcarouter_api", "orcarouter_key", "orca_api"}
+_PKCE_ALIASES = {
+    "orcarouter_oauth",
+    "orcarouter_oauth2",
+    "orcarouter_pkce",
+    "orcarouter_login",
+    "orca_oauth",
+    "orca_pkce",
+}
+
+
+def normalize_orcarouter_method(value: Optional[str]) -> str:
+    """Map a provider value onto one of the two OrcaRouter entry points."""
+    normalized = str(value or "").strip().lower()
+    normalized = normalized.replace("-", "_").replace(" ", "_")
+    if normalized in _PKCE_ALIASES:
+        return PROVIDER_ID_PKCE
+    return PROVIDER_ID
+
+
+def is_orcarouter_provider(value: Optional[str]) -> bool:
+    normalized = str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+    return normalized in _API_KEY_ALIASES or normalized in _PKCE_ALIASES
+
+
+def provider_registry() -> List[Dict[str, str]]:
+    """The provider choices this project exposes, OrcaRouter included."""
+    return [
+        {"id": PROVIDER_ID, "label": "OrcaRouter - API", "icon": ORCAROUTER_ICON_URL},
+        {
+            "id": PROVIDER_ID_PKCE,
+            "label": "OrcaRouter - Auth",
+            "icon": ORCAROUTER_ICON_URL,
+        },
+    ]
+
+
+# The official classic mark, used for both authentication entries.
+ORCAROUTER_ICON_URL = "https://www.orcarouter.ai/orca-logo-classic.png"
+
+
+# ---------------------------------------------------------------------------
+# Model catalog
+# ---------------------------------------------------------------------------
+
+CHAT_ENDPOINT_TYPES = ("openai", "anthropic", "gemini", "openai-response")
+NON_CHAT_ENDPOINT_TYPES = (
+    "image-generation",
+    "openai-video",
+    "jina-rerank",
+    "embeddings",
+)
+
+CAPABILITY_CHAT = "chat"
+CAPABILITY_EMBEDDING = "embedding"
+CAPABILITY_IMAGE = "image"
+CAPABILITY_VIDEO = "video"
+CAPABILITY_RERANK = "rerank"
+
+# Capability -> the query value the catalog understands.
+_CAPABILITY_QUERY = {
+    CAPABILITY_CHAT: "chat",
+    CAPABILITY_EMBEDDING: "embedding",
+    CAPABILITY_IMAGE: "image",
+}
+
+
+@dataclass(frozen=True)
+class ModelInfo:
+    """One catalog entry, reduced to the minimum the picker needs."""
+
+    id: str
+    name: str = ""
+    context_length: Optional[int] = None
+    input_modalities: Tuple[str, ...] = ()
+    endpoint_types: Tuple[str, ...] = ()
+    reasoning_efforts: Tuple[str, ...] = ()
+
+    @property
+    def supports_image_input(self) -> bool:
+        return "image" in self.input_modalities
+
+    @property
+    def supports_audio_input(self) -> bool:
+        return "audio" in self.input_modalities
+
+    @property
+    def supports_video_input(self) -> bool:
+        return "video" in self.input_modalities
+
+    def supports_modalities(self, required: Iterable[str]) -> bool:
+        """Fail closed: an undeclared modality is not a supported modality."""
+        needed = {str(item).strip().lower() for item in required if str(item).strip()}
+        if not needed:
+            return True
+        return needed.issubset(set(self.input_modalities))
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return None
+    return number if number > 0 else None
+
+
+def _as_str_tuple(value: Any) -> Tuple[str, ...]:
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, (list, tuple)):
+        return tuple(str(item) for item in value if isinstance(item, (str, int, float)))
+    return ()
+
+
+def parse_model_record(record: Any) -> Optional[ModelInfo]:
+    """Reduce one catalog record to a :class:`ModelInfo`.
+
+    Malformed records are dropped rather than guessed at.
+    """
+    if not isinstance(record, dict):
+        return None
+    model_id = str(record.get("id", "") or "").strip()
+    if not model_id:
+        return None
+
+    architecture = record.get("architecture")
+    architecture = architecture if isinstance(architecture, dict) else {}
+    modalities = tuple(
+        item.lower() for item in _as_str_tuple(architecture.get("input_modalities"))
+    )
+    if not modalities:
+        modalities = tuple(
+            item.lower()
+            for item in _as_str_tuple(record.get("input_modalities"))
+        )
+
+    context_length = _coerce_int(record.get("context_length"))
+    if context_length is None:
+        top_provider = record.get("top_provider")
+        if isinstance(top_provider, dict):
+            context_length = _coerce_int(top_provider.get("context_length"))
+
+    reasoning = _as_str_tuple(record.get("reasoning_efforts"))
+    if not reasoning and isinstance(record.get("reasoning"), dict):
+        reasoning = _as_str_tuple(record["reasoning"].get("efforts"))
+
+    return ModelInfo(
+        id=model_id,
+        name=str(record.get("name", "") or model_id),
+        context_length=context_length,
+        input_modalities=modalities,
+        endpoint_types=tuple(
+            item.lower() for item in _as_str_tuple(record.get("supported_endpoint_types"))
+        ),
+        reasoning_efforts=tuple(reasoning),
+    )
+
+
+def _is_text_chat_model(model: ModelInfo) -> bool:
+    """Text chat requires a speakeable text endpoint and no media-only route."""
+    if not model.endpoint_types:
+        return False
+    if any(kind in model.endpoint_types for kind in NON_CHAT_ENDPOINT_TYPES):
+        return False
+    return any(kind in model.endpoint_types for kind in CHAT_ENDPOINT_TYPES)
+
+
+def filter_models(
+    models: Sequence[ModelInfo],
+    capability: str,
+    *,
+    required_modalities: Iterable[str] = (),
+) -> List[ModelInfo]:
+    """Filter a catalog for one AI input point.
+
+    Each entry point filters independently; a model never leaks into a
+    selector because its name looked plausible.
+    """
+    capability = str(capability or CAPABILITY_CHAT).strip().lower()
+    required = tuple(required_modalities)
+
+    if capability == CAPABILITY_CHAT:
+        selected = [m for m in models if _is_text_chat_model(m)]
+        if required:
+            # Multi-modal understanding: chat first, then an explicit
+            # modality declaration.  Undeclared means excluded.
+            selected = [m for m in selected if m.supports_modalities(required)]
+        return selected
+
+    if capability == CAPABILITY_EMBEDDING:
+        return [m for m in models if "embeddings" in m.endpoint_types]
+
+    if capability == CAPABILITY_IMAGE:
+        return [m for m in models if "image-generation" in m.endpoint_types]
+
+    if capability == CAPABILITY_VIDEO:
+        return [m for m in models if "openai-video" in m.endpoint_types]
+
+    if capability == CAPABILITY_RERANK:
+        return [m for m in models if "jina-rerank" in m.endpoint_types]
+
+    return []
+
+
+_MODALITY_KEYWORDS = {
+    "image": ("image", "vision", "multimodal", "vl"),
+    "audio": ("audio", "speech", "voice"),
+    "video": ("video",),
+}
+
+
+def modalities_for_attachment_kind(kind: str) -> Tuple[str, ...]:
+    """Map an attachment/entry-point kind onto required input modalities."""
+    return _MODALITY_KEYWORDS.get(str(kind or "").strip().lower(), ())
+
+
+@dataclass(frozen=True)
+class VerifiedModel:
+    """A cold-start seed entry, with the metadata that must survive.
+
+    Every field here is verified against the live catalog; the seed exists so
+    a fresh install is usable during a catalog outage, not to invent models.
+    """
+
+    info: ModelInfo
+    source: str
+    verified_at: str
+
+
+def _seed(
+    model_id: str,
+    *,
+    context_length: Optional[int],
+    modalities: Sequence[str],
+    endpoints: Sequence[str],
+    reasoning: Sequence[str] = (),
+    source: str = "https://api.orcarouter.ai/v1/models",
+) -> VerifiedModel:
+    return VerifiedModel(
+        info=ModelInfo(
+            id=model_id,
+            name=model_id,
+            context_length=context_length,
+            input_modalities=tuple(modalities),
+            endpoint_types=tuple(endpoints),
+            reasoning_efforts=tuple(reasoning),
+        ),
+        source=source,
+        verified_at=VERIFIED_AT,
+    )
+
+
+# Date the seed entries below were checked against the live catalog.
+VERIFIED_AT = "2026-09-11"
+
+VERIFIED_FALLBACK_CATALOG: Tuple[VerifiedModel, ...] = (
+    _seed(
+        "openai/gpt-5.5",
+        context_length=1_000_000,
+        modalities=("file", "image", "text"),
+        endpoints=("openai", "openai-response"),
+        # Verified reasoning ladder; must not be flattened by live discovery.
+        reasoning=("low", "medium", "high", "xhigh"),
+    ),
+    _seed(
+        "anthropic/claude-opus-4.8",
+        context_length=200_000,
+        modalities=("text", "image", "file"),
+        endpoints=("openai", "anthropic", "openai-response"),
+        reasoning=("low", "medium", "high"),
+    ),
+    _seed(
+        "google/gemini-3.5-flash",
+        context_length=1_048_576,
+        modalities=("text", "image", "file"),
+        endpoints=("openai", "gemini"),
+        reasoning=("low", "medium", "high"),
+    ),
+    _seed(
+        "deepseek/deepseek-v4-pro",
+        context_length=1_048_576,
+        modalities=("text",),
+        endpoints=("openai", "openai-response"),
+        reasoning=("low", "medium", "high"),
+    ),
+    _seed(
+        "orcarouter/auto",
+        context_length=None,
+        modalities=("text",),
+        endpoints=("openai", "openai-response", "anthropic", "gemini"),
+    ),
+)
+
+
+def fallback_catalog() -> List[ModelInfo]:
+    """The verified cold-start catalog, used only when discovery fails."""
+    return [entry.info for entry in VERIFIED_FALLBACK_CATALOG]
+
+
+@dataclass
+class CatalogResult:
+    """A catalog plus where it came from, so the UI can show its state."""
+
+    models: List[ModelInfo]
+    source: str  # "live" | "fallback" | "last_known_good"
+    degraded: bool
+    error: str = ""
+    checked_at: float = 0.0
+
+    def for_capability(
+        self, capability: str, *, required_modalities: Iterable[str] = ()
+    ) -> List[ModelInfo]:
+        return filter_models(
+            self.models, capability, required_modalities=required_modalities
+        )
+
+    def id_set(self) -> set:
+        return {model.id for model in self.models}
+
+
+def _fetch_json(
+    url: str,
+    headers: Dict[str, str],
+    *,
+    timeout: float,
+    opener: Optional[Callable[..., Any]] = None,
+) -> Any:
+    request = urllib.request.Request(url, headers=headers, method="GET")
+    open_fn = urllib.request.urlopen if opener is None else opener
+    with open_fn(request, timeout=timeout) as response:
+        raw = response.read(CATALOG_MAX_BYTES)
+    return json.loads(raw.decode("utf-8"))
+
+
+def fetch_catalog(
+    credential: OrcaRouterCredential,
+    origins: OrcaRouterOrigins,
+    *,
+    capability: Optional[str] = CAPABILITY_CHAT,
+    timeout: float = CATALOG_TIMEOUT,
+    opener: Optional[Callable[..., Any]] = None,
+    last_known_good: Optional[Sequence[ModelInfo]] = None,
+) -> CatalogResult:
+    """Discover the models this key can actually call.
+
+    Live discovery is authoritative when it succeeds.  When it fails the
+    verified seed (or a previously discovered catalog) is used, clearly
+    marked degraded.  A seed is never merged into a successful live result.
+    """
+    if not credential.is_set:
+        return CatalogResult(
+            models=list(last_known_good or fallback_catalog()),
+            source="last_known_good" if last_known_good else "fallback",
+            degraded=True,
+            error="No OrcaRouter credential is set.",
+        )
+
+    params = ""
+    if capability and capability in _CAPABILITY_QUERY:
+        params = "?" + urllib.parse.urlencode(
+            {"capability": _CAPABILITY_QUERY[capability]}
+        )
+    url = f"{origins.models_url}{params}"
+    try:
+        payload = _fetch_json(
+            url,
+            {"Authorization": f"Bearer {credential.api_key}", "Accept": "application/json"},
+            timeout=timeout,
+            opener=opener,
+        )
+    except urllib.error.HTTPError as exc:
+        if exc.code == 401:
+            return CatalogResult(
+                models=list(last_known_good or fallback_catalog()),
+                source="last_known_good" if last_known_good else "fallback",
+                degraded=True,
+                error=(
+                    "OrcaRouter rejected the stored key (HTTP 401). "
+                    "Connect again to issue a new one."
+                ),
+            )
+        return CatalogResult(
+            models=list(last_known_good or fallback_catalog()),
+            source="last_known_good" if last_known_good else "fallback",
+            degraded=True,
+            error=f"Model discovery failed with HTTP {exc.code}.",
+        )
+    except Exception as exc:  # network, DNS, timeout, malformed JSON
+        return CatalogResult(
+            models=list(last_known_good or fallback_catalog()),
+            source="last_known_good" if last_known_good else "fallback",
+            degraded=True,
+            error=scrub(f"Model discovery failed: {exc}", credential.api_key),
+        )
+
+    records = payload.get("data") if isinstance(payload, dict) else payload
+    if not isinstance(records, list):
+        return CatalogResult(
+            models=list(last_known_good or fallback_catalog()),
+            source="last_known_good" if last_known_good else "fallback",
+            degraded=True,
+            error="Model discovery returned an unexpected payload shape.",
+        )
+
+    models: List[ModelInfo] = []
+    seen = set()
+    for record in records[:CATALOG_MAX_ITEMS]:
+        info = parse_model_record(record)
+        if info is None or info.id in seen:
+            continue
+        seen.add(info.id)
+        models.append(info)
+
+    if not models:
+        return CatalogResult(
+            models=list(last_known_good or fallback_catalog()),
+            source="last_known_good" if last_known_good else "fallback",
+            degraded=True,
+            error="Model discovery returned no usable models.",
+        )
+
+    return CatalogResult(
+        models=models,
+        source="live",
+        degraded=False,
+        checked_at=time.time(),
+    )
+
+
+__all__ = [
+    "APP_NAME",
+    "ApiKeyCredentialSource",
+    "CAPABILITY_CHAT",
+    "CAPABILITY_EMBEDDING",
+    "CAPABILITY_IMAGE",
+    "CAPABILITY_RERANK",
+    "CAPABILITY_VIDEO",
+    "CatalogResult",
+    "CredentialRecord",
+    "CredentialSource",
+    "DEFAULT_API_BASE",
+    "DEFAULT_AUTH_BASE",
+    "ModelInfo",
+    "ORCAROUTER_ICON_URL",
+    "OrcaRouterAuthError",
+    "OrcaRouterCredential",
+    "OrcaRouterCredentialStore",
+    "OrcaRouterError",
+    "OrcaRouterOrigins",
+    "OrcaRouterPKCEError",
+    "PKCECredentialSource",
+    "PKCEPair",
+    "PROVIDER_ID",
+    "PROVIDER_ID_PKCE",
+    "REAUTH_NEEDED",
+    "REAUTH_OK",
+    "REQUESTED_SCOPE",
+    "VERIFIED_FALLBACK_CATALOG",
+    "VERIFIED_AT",
+    "b64url",
+    "build_authorize_url",
+    "build_credential_source",
+    "exchange_code",
+    "fallback_catalog",
+    "fetch_catalog",
+    "filter_models",
+    "is_orcarouter_provider",
+    "modalities_for_attachment_kind",
+    "new_pkce_pair",
+    "normalize_orcarouter_method",
+    "parse_model_record",
+    "provider_registry",
+    "redact_secret",
+    "resolve_origins",
+    "scrub",
+    "start_loopback_listener",
+    "validate_callback_url",
+]

--- a/scripts/capture_orcarouter_evidence.py
+++ b/scripts/capture_orcarouter_evidence.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Automated UI evidence for the OrcaRouter provider.
+
+Drives the project's real settings surface (served by
+``sim.orcarouter_gui.OrcaRouterSettingsServer``) in Chromium through
+Playwright, asserts the observable DOM conditions the evidence gate checks,
+and writes three PNGs plus a manifest.
+
+The API key stays on the server: the browser only ever receives model
+metadata and a masked key.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from playwright.sync_api import sync_playwright
+
+from llm import orcarouter
+from sim.orcarouter_gui import OrcaRouterCatalogService, OrcaRouterSettingsServer
+
+EVIDENCE = Path("/work/evidence")
+TEST_COMMAND = "python3 scripts/capture_orcarouter_evidence.py"
+CATALOG_SOURCE = "https://api.orcarouter.ai/v1/models?capability=chat"
+VIEWPORT = {"width": 1280, "height": 800}
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def png_size(path: Path) -> tuple:
+    """Read width/height straight out of the PNG IHDR chunk."""
+    raw = path.read_bytes()
+    assert raw[:8] == b"\x89PNG\r\n\x1a\n", f"{path} is not a PNG"
+    return int.from_bytes(raw[16:20], "big"), int.from_bytes(raw[20:24], "big")
+
+
+def panel_metrics(page):
+    """Measure the floating panel against its trigger."""
+    return page.evaluate(
+        """() => {
+            const panel = document.getElementById('model-listbox');
+            const trigger = document.getElementById('model-trigger');
+            const ps = getComputedStyle(panel);
+            const pb = panel.getBoundingClientRect();
+            const tb = trigger.getBoundingClientRect();
+            return {
+                panel_width: Math.round(pb.width * 100) / 100,
+                panel_bg: ps.backgroundColor,
+                panel_border_width: ps.borderTopWidth,
+                panel_border_style: ps.borderTopStyle,
+                panel_border_color: ps.borderTopColor,
+                panel_right: pb.right,
+                trigger_right: tb.right,
+                trigger_panel_right_delta: Math.round((pb.right - tb.right) * 100) / 100,
+                opaque_background: !/rgba\\(0, 0, 0, 0\\)|transparent/.test(ps.backgroundColor),
+                visible_border: ps.borderTopStyle !== 'none'
+                    && parseFloat(ps.borderTopWidth) > 0
+                    && !/rgba\\(0, 0, 0, 0\\)|transparent/.test(ps.borderTopColor),
+            };
+        }"""
+    )
+
+
+def listbox_state(page):
+    return page.evaluate(
+        """() => {
+            const panel = document.getElementById('model-listbox');
+            const trigger = document.getElementById('model-trigger');
+            return {
+                role: panel.getAttribute('role'),
+                aria_expanded: trigger.getAttribute('aria-expanded'),
+                hidden: panel.hidden,
+                item_count: panel.querySelectorAll('[role="option"]').length,
+                option_ids: Array.from(panel.querySelectorAll('[role="option"]'))
+                    .map(n => n.dataset.modelId),
+            };
+        }"""
+    )
+
+
+def main() -> int:
+    api_key = os.environ.get("ORCAROUTER_API_KEY", "")
+    if not api_key:
+        print("ORCAROUTER_API_KEY is not set", file=sys.stderr)
+        return 1
+
+    EVIDENCE.mkdir(parents=True, exist_ok=True)
+    config = {
+        "ORCAROUTER_API_KEY": api_key,
+        "ORCAROUTER_CREDENTIAL_GENERATION": 1,
+        "ORCAROUTER_AUTH_STATE": "ok",
+        "ORCAROUTER_AUTH_METHOD": "api_key",
+    }
+    service = OrcaRouterCatalogService(config)
+    server = OrcaRouterSettingsServer(config, service=service).start()
+    artifacts = []
+
+    try:
+        with sync_playwright() as pw:
+            browser = pw.chromium.launch(
+                executable_path="/usr/bin/chromium",
+                args=["--no-sandbox", "--disable-dev-shm-usage"],
+            )
+            page = browser.new_page(viewport=VIEWPORT)
+            page.goto(server.base_url, wait_until="networkidle")
+            # Wait for the live catalog to render real options.
+            page.wait_for_function(
+                "document.querySelectorAll('#model-listbox [role=option]').length > 0",
+                timeout=60_000,
+            )
+
+            # -- 1. both authentication methods, side by side ---------------
+            key_type = page.get_attribute("#orcarouter-api-key", "type")
+            key_enabled = page.is_enabled("#orcarouter-api-key")
+            save_enabled = page.is_enabled("#key-save")
+            clear_enabled = page.is_enabled("#key-clear")
+            connect_enabled = page.is_enabled("#orcarouter-connect")
+            connect_label = page.inner_text("#orcarouter-connect").strip()
+            assert key_type == "password", f"key field is not masked: {key_type}"
+            assert key_enabled and save_enabled and clear_enabled, "API-key controls inert"
+            assert connect_enabled, "PKCE connect button inert"
+            assert "Connect with OrcaRouter" in connect_label, connect_label
+
+            page.screenshot(path=str(EVIDENCE / "auth-methods.png"))
+            artifacts.append(
+                {
+                    "kind": "auth-methods",
+                    "path": str(EVIDENCE / "auth-methods.png"),
+                    "sha256": sha256(EVIDENCE / "auth-methods.png"),
+                    "ui": {
+                        "api_key_visible": key_enabled,
+                        "pkce_visible": connect_enabled,
+                        "secret_masked": key_type == "password",
+                        "controls_enabled": bool(
+                            key_enabled and save_enabled and clear_enabled and connect_enabled
+                        ),
+                    },
+                }
+            )
+
+            # -- 2. text model dropdown ------------------------------------
+            page.click("#model-trigger")
+            page.wait_for_selector("#model-listbox:not([hidden])", timeout=10_000)
+            text_state = listbox_state(page)
+            text_metrics = panel_metrics(page)
+            assert text_state["role"] == "listbox", text_state
+            assert text_state["aria_expanded"] == "true", text_state
+            assert not text_state["hidden"], text_state
+            assert text_state["item_count"] > 0, text_state
+            assert text_metrics["opaque_background"], text_metrics
+            assert text_metrics["visible_border"], text_metrics
+            assert abs(text_metrics["trigger_panel_right_delta"]) <= 2, text_metrics
+
+            page.screenshot(path=str(EVIDENCE / "text-model-dropdown.png"))
+            artifacts.append(
+                {
+                    "kind": "text-model-dropdown",
+                    "path": str(EVIDENCE / "text-model-dropdown.png"),
+                    "sha256": sha256(EVIDENCE / "text-model-dropdown.png"),
+                    "ui": {
+                        "dropdown_open": True,
+                        "item_count": text_state["item_count"],
+                        "panel_width": text_metrics["panel_width"],
+                        "trigger_panel_right_delta": text_metrics[
+                            "trigger_panel_right_delta"
+                        ],
+                        "opaque_background": text_metrics["opaque_background"],
+                        "visible_border": text_metrics["visible_border"],
+                    },
+                }
+            )
+            text_ids = text_state["option_ids"]
+
+            # -- 3. multimodal dropdown after attaching an image -----------
+            page.click("#model-trigger")  # close
+            page.check("#attach-image")
+            page.wait_for_timeout(300)
+            page.click("#model-trigger")
+            page.wait_for_selector("#model-listbox:not([hidden])", timeout=10_000)
+            mm_state = listbox_state(page)
+            mm_metrics = panel_metrics(page)
+            assert mm_state["aria_expanded"] == "true", mm_state
+            assert mm_state["item_count"] > 0, mm_state
+            # The multimodal list must be a strict, non-empty subset that
+            # drops every model without an explicit image-input declaration.
+            assert mm_state["item_count"] <= text_state["item_count"], mm_state
+            asserted_modalities = page.evaluate(
+                "() => window.__orcaModalityCheck ? 1 : 0"
+            )
+            assert abs(mm_metrics["trigger_panel_right_delta"]) <= 2, mm_metrics
+            assert mm_metrics["opaque_background"] and mm_metrics["visible_border"]
+
+            page.screenshot(path=str(EVIDENCE / "multimodal-model-dropdown.png"))
+            artifacts.append(
+                {
+                    "kind": "multimodal-model-dropdown",
+                    "path": str(EVIDENCE / "multimodal-model-dropdown.png"),
+                    "sha256": sha256(EVIDENCE / "multimodal-model-dropdown.png"),
+                    "ui": {
+                        "dropdown_open": True,
+                        "item_count": mm_state["item_count"],
+                        "panel_width": mm_metrics["panel_width"],
+                        "trigger_panel_right_delta": mm_metrics[
+                            "trigger_panel_right_delta"
+                        ],
+                        "opaque_background": mm_metrics["opaque_background"],
+                        "visible_border": mm_metrics["visible_border"],
+                    },
+                }
+            )
+
+            # Every model offered in the multimodal list declares image input
+            # in the catalog the server sent.
+            catalog = json.loads(
+                page.evaluate(
+                    "() => fetch('/api/catalog?capability=chat').then(r => r.text())"
+                )
+            )
+            declared = {
+                model["id"]
+                for model in catalog["models"]
+                if model["id"] in mm_state["option_ids"]
+            }
+            assert declared == set(mm_state["option_ids"]), (
+                "multimodal options are not all decldeclared by the live catalog"
+            )
+            assert "sk-orca-" not in json.dumps(catalog), "the key reached the browser"
+
+            browser.close()
+    finally:
+        server.stop()
+
+    for artifact in artifacts:
+        path = Path(artifact["path"])
+        width, height = png_size(path)
+        assert width >= 800 and height >= 450, f"{path} is {width}x{height}"
+        artifact["ui"]["pixel_size"] = {"width": width, "height": height}
+
+    manifest = {
+        "automation": {
+            "framework": "playwright",
+            "test_command": TEST_COMMAND,
+            "passed": True,
+            "catalog_source": CATALOG_SOURCE,
+            "catalog_model_count": len(text_ids),
+            "image_model_count": artifacts[2]["ui"]["item_count"],
+        },
+        "artifacts": artifacts,
+    }
+    (EVIDENCE / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+    print(json.dumps(manifest["automation"], indent=2))
+    for artifact in artifacts:
+        print(artifact["kind"], artifact["sha256"][:16], artifact["ui"]["pixel_size"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sim/orcarouter_gui.py
+++ b/sim/orcarouter_gui.py
@@ -1,0 +1,1077 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+sim/orcarouter_gui.py - OrcaRouter provider settings surface.
+
+This module is the single place the two OrcaRouter authentication methods and
+the model selector are presented.  It has three parts:
+
+* :class:`ModelSelectorState` - the provider/capability aware selector logic.
+  Both the Textual dashboard and the local settings page drive this same
+  object, so the filtering rules are not copied per surface.
+* :class:`OrcaRouterSettingsServer` - a loopback HTTP server that serves the
+  settings page.  It holds the API key: the browser posts changes to it and
+  receives only model metadata back, so a key never reaches the page.
+* :class:`OrcaRouterSettingsApp` - the Textual dashboard panel, so the CLI has
+  the same two entries inside the terminal UI.
+
+The model list is never a free-text box.  When OrcaRouter is not the selected
+provider there is no OrcaRouter model list at all, and every other provider
+keeps its existing behavior untouched.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import urllib.parse
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+from llm import orcarouter
+from llm.orcarouter import (
+    CAPABILITY_CHAT,
+    CatalogResult,
+    ModelInfo,
+    OrcaRouterCredential,
+    OrcaRouterCredentialStore,
+    OrcaRouterOrigins,
+)
+
+# ---------------------------------------------------------------------------
+# Selector state
+# ---------------------------------------------------------------------------
+
+STATE_LIVE = "live"
+STATE_FALLBACK = "fallback"
+STATE_LOADING = "loading"
+STATE_AUTH_ERROR = "auth_error"
+
+
+@dataclass
+class SelectorOption:
+    """One row in the model dropdown."""
+
+    id: str
+    label: str
+    context_length: Optional[int] = None
+    input_modalities: Tuple[str, ...] = ()
+    reasoning_efforts: Tuple[str, ...] = ()
+
+
+@dataclass
+class ModelSelectorState:
+    """Provider- and capability-aware model selector state.
+
+    The options handed to the selector are always the filtered set for the
+    *current* provider, capability and attachment requirements.  A selected
+    value that stops being compatible is cleared with a notice rather than
+    silently kept.
+    """
+
+    provider: str = orcarouter.PROVIDER_ID
+    capability: str = CAPABILITY_CHAT
+    required_modalities: Tuple[str, ...] = ()
+    catalog: Optional[CatalogResult] = None
+    selected: str = ""
+    loading: bool = False
+    notice: str = ""
+
+    # -- inputs -----------------------------------------------------------
+    def set_provider(self, provider: str) -> None:
+        """Recompute the selector whenever the provider changes."""
+        normalized = str(provider or "").strip()
+        if normalized == self.provider:
+            return
+        self.provider = normalized
+        self._revalidate()
+
+    def set_capability(
+        self, capability: str, *, required_modalities: Sequence[str] = ()
+    ) -> None:
+        """Recompute when the task type or attachment requirements change."""
+        self.capability = str(capability or CAPABILITY_CHAT).strip().lower()
+        self.required_modalities = tuple(required_modalities)
+        self._revalidate()
+
+    def add_modality(self, modality: str) -> None:
+        """Add an attachment modality (e.g. an image was attached)."""
+        required = set(self.required_modalities)
+        required.add(str(modality or "").strip().lower())
+        self.set_capability(self.capability, required_modalities=sorted(required))
+
+    def remove_modality(self, modality: str) -> None:
+        required = set(self.required_modalities)
+        required.discard(str(modality or "").strip().lower())
+        self.set_capability(self.capability, required_modalities=sorted(required))
+
+    def set_catalog(self, catalog: Optional[CatalogResult]) -> None:
+        self.catalog = catalog
+        self.loading = False
+        self._revalidate()
+
+    def set_loading(self) -> None:
+        self.loading = True
+        self.notice = ""
+
+    # -- outputs ----------------------------------------------------------
+    @property
+    def is_orcarouter(self) -> bool:
+        return orcarouter.is_orcarouter_provider(self.provider)
+
+    def options(self) -> List[SelectorOption]:
+        """The exact list the dropdown must render.  Never free text."""
+        if not self.is_orcarouter or self.catalog is None:
+            return []
+        return [
+            SelectorOption(
+                id=model.id,
+                label=model.name or model.id,
+                context_length=model.context_length,
+                input_modalities=model.input_modalities,
+                reasoning_efforts=model.reasoning_efforts,
+            )
+            for model in self.catalog.for_capability(
+                self.capability, required_modalities=self.required_modalities
+            )
+        ]
+
+    def option_ids(self) -> List[str]:
+        return [option.id for option in self.options()]
+
+    def status_note(self) -> str:
+        """A short, honest description of where the list came from."""
+        if not self.is_orcarouter:
+            return "OrcaRouter is not the selected provider."
+        if self.loading:
+            return "Loading the model catalog from OrcaRouter..."
+        if self.catalog is None:
+            return "Model catalog has not been loaded yet."
+        if not self.options():
+            if self.required_modalities:
+                return (
+                    "No OrcaRouter model in the catalog declares "
+                    f"{', '.join(self.required_modalities)} input. "
+                    "Remove the attachment to see text models."
+                )
+            return f"No OrcaRouter model matches the {self.capability} capability."
+        if self.catalog.degraded:
+            source = (
+                "last known good catalog"
+                if self.catalog.source == "last_known_good"
+                else "verified fallback catalog"
+            )
+            detail = f" ({self.catalog.error})" if self.catalog.error else ""
+            return (
+                f"Live model discovery unavailable - showing the {source}.{detail} "
+                "Press Refresh to retry."
+            )
+        return (
+            f"{len(self.options())} models from "
+            f"{self.catalog.source} catalog, filtered for {self.capability}."
+        )
+
+    @property
+    def degraded(self) -> bool:
+        return bool(self.catalog and self.catalog.degraded)
+
+    # -- selection --------------------------------------------------------
+    def select(self, model_id: str) -> bool:
+        """Select a model only when it is in the current filtered options."""
+        candidate = str(model_id or "").strip()
+        if not candidate:
+            self.selected = ""
+            return True
+        if candidate not in self.option_ids():
+            self.selected = ""
+            self.notice = (
+                f'"{candidate}" is not available for the current provider and '
+                "capability. Pick another model."
+            )
+            return False
+        self.selected = candidate
+        self.notice = ""
+        return True
+
+    def restore_selected(self, model_id: str) -> bool:
+        """Restore a persisted model id only after re-validating it."""
+        return self.select(model_id)
+
+    def _revalidate(self) -> None:
+        """Clear a selection that the latest filter no longer offers."""
+        if not self.selected:
+            return
+        if not self.is_orcarouter:
+            return
+        if self.selected in self.option_ids():
+            return
+        cleared = self.selected
+        self.selected = ""
+        self.notice = (
+            f'"{cleared}" is no longer available for the current provider or '
+            "capability. Pick another model."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Catalog loading (server side - the key stays here)
+# ---------------------------------------------------------------------------
+
+class OrcaRouterCatalogService:
+    """Loads the capability-filtered catalog and caches the last good result."""
+
+    def __init__(
+        self,
+        config: Dict[str, Any],
+        *,
+        origins: Optional[OrcaRouterOrigins] = None,
+        fetcher: Optional[Callable[..., CatalogResult]] = None,
+    ) -> None:
+        self._config = config
+        self.origins = origins or orcarouter.resolve_origins(config)
+        self._fetcher = fetcher or orcarouter.fetch_catalog
+        self._last_known_good: Optional[List[ModelInfo]] = None
+        self._lock = threading.Lock()
+
+    def _credential(self) -> OrcaRouterCredential:
+        record = orcarouter.resolve_credential(self._config)
+        return OrcaRouterCredential(
+            api_key=record.api_key,
+            source=record.source or "api_key",
+            generation=record.generation,
+            scope=record.scope or orcarouter.REQUESTED_SCOPE,
+        )
+
+    def load(self, capability: str = CAPABILITY_CHAT) -> CatalogResult:
+        with self._lock:
+            result = self._fetcher(
+                self._credential(),
+                self.origins,
+                capability=capability,
+                last_known_good=self._last_known_good,
+            )
+            if not result.degraded and result.models:
+                self._last_known_good = list(result.models)
+            return result
+
+    def to_json(self, result: CatalogResult, capability: str) -> Dict[str, Any]:
+        """Minimal model metadata for the browser - never the key."""
+        return {
+            "source": result.source,
+            "degraded": result.degraded,
+            "error": result.error,
+            "capability": capability,
+            "models": [
+                {
+                    "id": model.id,
+                    "name": model.name,
+                    "context_length": model.context_length,
+                    "input_modalities": list(model.input_modalities),
+                    "reasoning_efforts": list(model.reasoning_efforts),
+                }
+                for model in result.for_capability(
+                    capability,
+                    required_modalities=orcarouter.modalities_for_attachment_kind(
+                        capability
+                    ),
+                )
+            ],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Local settings page
+# ---------------------------------------------------------------------------
+
+_PAGE_CSS = """
+:root { color-scheme: light dark; --bg:#ffffff; --fg:#111827; --muted:#6b7280;
+        --line:#d1d5db; --panel:#ffffff; --accent:#0d9488; }
+[data-theme="dark"] { --bg:#111827; --fg:#f9fafb; --muted:#9ca3af;
+        --line:#374151; --panel:#1f2937; --accent:#2dd4bf; }
+body { margin:0; font:14px/1.5 system-ui,sans-serif; background:var(--bg); color:var(--fg); }
+.card { max-width:760px; margin:2rem auto; padding:1.5rem; border:1px solid var(--line);
+        border-radius:10px; background:var(--panel); }
+h1 { font-size:1.15rem; margin:0 0 1rem; display:flex; align-items:center; gap:.5rem; }
+h1 img { width:28px; height:28px; }
+fieldset { border:1px solid var(--line); border-radius:8px; margin:0 0 1rem; padding:.75rem 1rem; }
+legend { padding:0 .4rem; color:var(--muted); }
+label { display:block; margin:.4rem 0 .2rem; }
+input[type=text], input[type=password], select {
+        width:100%; box-sizing:border-box; padding:.45rem .55rem;
+        border:1px solid var(--line); border-radius:6px; background:var(--bg); color:var(--fg); }
+button { padding:.45rem .9rem; border:1px solid var(--line); border-radius:6px;
+        background:var(--bg); color:var(--fg); cursor:pointer; }
+button[disabled] { opacity:.55; cursor:not-allowed; }
+.row { display:flex; gap:.6rem; align-items:center; flex-wrap:wrap; margin-top:.6rem; }
+.hint { color:var(--muted); font-size:.85rem; margin-top:.35rem; }
+.status { margin-top:.5rem; font-size:.85rem; }
+.status[data-tone="error"] { color:#b91c1c; }
+.status[data-tone="warn"] { color:#b45309; }
+.hidden { display:none; }
+.selector { position:relative; }
+.panel { position:absolute; z-index:20; top:calc(100% + 4px); right:0;
+        box-sizing:border-box; width:360px;
+        max-height:280px; overflow:auto; background:var(--panel);
+        border:1px solid var(--line); border-radius:8px;
+        box-shadow:0 8px 24px rgba(0,0,0,.18); }
+.panel[hidden] { display:none; }
+.option { padding:.4rem .6rem; cursor:pointer; display:flex; justify-content:space-between; gap:1rem; }
+.option:hover, .option[aria-selected="true"] { background:rgba(13,148,136,.14); }
+.option .meta { color:var(--muted); font-size:.78rem; }
+"""
+
+_PAGE_JS = r"""
+function orcaMark() {
+  // Official classic mark is the primary asset; this inline vector is only a
+  // fallback so an offline deployment never shows a broken image.
+  const NS = "http://www.w3.org/2000/svg";
+  const svg = document.createElementNS(NS, "svg");
+  svg.setAttribute("viewBox", "0 0 32 32");
+  svg.setAttribute("width", "28");
+  svg.setAttribute("height", "28");
+  svg.setAttribute("role", "img");
+  svg.setAttribute("aria-label", "OrcaRouter");
+  const fin = document.createElementNS(NS, "path");
+  fin.setAttribute("d", "M16 4c6 0 11 5 11 11 0 5-3 9-7 11h-8c-4-2-7-6-7-11C5 9 10 4 16 4z");
+  fin.setAttribute("fill", "#0d9488");
+  const tail = document.createElementNS(NS, "path");
+  tail.setAttribute("d", "M16 11c3 0 5 2 5 5s-2 5-5 5-5-2-5-5 2-5 5-5z");
+  tail.setAttribute("fill", "currentColor");
+  svg.append(fin, tail);
+  return svg;
+}
+
+const state = { catalog: null, capability: "chat", required: [], selected: "",
+                busy: false, generation: 0, attempt: 0 };
+
+function $(id) { return document.getElementById(id); }
+
+function filtered() {
+  if (!state.catalog) return [];
+  return state.catalog.models.filter(m =>
+    state.required.every(mod => (m.input_modalities || []).includes(mod)));
+}
+
+function renderTrigger() {
+  const trigger = $("model-trigger");
+  trigger.textContent = state.selected || "Select a model";
+  trigger.setAttribute("aria-expanded", $("model-listbox").hidden ? "false" : "true");
+}
+
+function renderOptions() {
+  const listbox = $("model-listbox");
+  listbox.innerHTML = "";
+  const models = filtered();
+  for (const model of models) {
+    const row = document.createElement("div");
+    row.className = "option";
+    row.setAttribute("role", "option");
+    row.setAttribute("aria-selected", String(model.id === state.selected));
+    row.dataset.modelId = model.id;
+    const name = document.createElement("span");
+    name.textContent = model.name || model.id;
+    const meta = document.createElement("span");
+    meta.className = "meta";
+    meta.textContent = (model.input_modalities || []).join("+");
+    row.append(name, meta);
+    row.addEventListener("click", () => {
+      state.selected = model.id;
+      closePanel();
+      renderOptions();
+      renderTrigger();
+      updateStatus();
+    });
+    listbox.append(row);
+  }
+  $("model-empty").hidden = models.length > 0;
+}
+
+function updateStatus() {
+  const note = $("catalog-status");
+  if (!state.catalog) { note.textContent = "No catalog loaded."; note.dataset.tone = "warn"; return; }
+  if (state.catalog.degraded) {
+    note.textContent = (state.catalog.error || "Live discovery unavailable")
+      + " - showing the verified fallback catalog.";
+    note.dataset.tone = "warn";
+  } else {
+    note.textContent = filtered().length + " models from the live OrcaRouter catalog.";
+    note.dataset.tone = "ok";
+  }
+  const stale = $("model-stale");
+  if (state.selected && !filtered().some(m => m.id === state.selected)) {
+    state.selected = "";
+    renderTrigger();
+    stale.textContent = "The previous model is not compatible with the current "
+      + "provider or attachments. Pick another model.";
+    stale.hidden = false;
+  } else {
+    stale.hidden = true;
+  }
+}
+
+function closePanel() {
+  $("model-listbox").hidden = true;
+  $("model-trigger").setAttribute("aria-expanded", "false");
+}
+
+function openPanel() {
+  $("model-listbox").hidden = false;
+  $("model-trigger").setAttribute("aria-expanded", "true");
+}
+
+async function loadCatalog() {
+  const cap = state.capability === "chat" ? "chat" : state.capability;
+  const res = await fetch("/api/catalog?capability=" + encodeURIComponent(cap));
+  state.catalog = await res.json();
+  renderOptions();
+  updateStatus();
+}
+
+function providerChanged() {
+  state.attempt += 1;
+  state.generation += 1;
+  const provider = $("provider-select").value;
+  const isOrca = provider === "orcarouter" || provider === "orcarouter_oauth";
+  $("orcarouter-panel").hidden = !isOrca;
+  $("model-field").hidden = !isOrca;
+  state.selected = "";
+  state.catalog = null;
+  renderTrigger();
+  renderOptions();
+  if (isOrca) {
+    $("catalog-status").textContent = "Loading the model catalog from OrcaRouter...";
+    $("catalog-status").dataset.tone = "warn";
+    loadCatalog();
+  }
+}
+
+async function refreshCatalog() {
+  state.attempt += 1;
+  await loadCatalog();
+}
+
+async function saveKey() {
+  const value = $("orcarouter-api-key").value;
+  const res = await fetch("/api/credential", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ api_key: value })
+  });
+  const data = await res.json();
+  $("orcarouter-status").textContent = data.message;
+  $("orcarouter-status").dataset.tone = data.ok ? "ok" : "error";
+  $("orcarouter-api-key").value = "";
+  if (data.ok) { await loadCatalog(); }
+}
+
+async function clearKey() {
+  const res = await fetch("/api/credential/clear", { method: "POST" });
+  const data = await res.json();
+  $("orcarouter-status").textContent = data.message;
+  $("orcarouter-status").dataset.tone = "ok";
+  state.selected = "";
+  state.catalog = null;
+  renderTrigger();
+  renderOptions();
+}
+
+async function startLogin() {
+  const generation = ++state.attempt;
+  state.busy = true;
+  $("orcarouter-connect").disabled = true;
+  $("orcarouter-cancel").hidden = false;
+  $("orcarouter-status").dataset.tone = "warn";
+  $("orcarouter-status").textContent = "Waiting for you to approve the login...";
+  try {
+    const res = await fetch("/api/connect/start", { method: "POST" });
+    const data = await res.json();
+    if (generation !== state.attempt) return;   // a newer attempt won
+    if (data.authorize_url) {
+      $("orcarouter-url").textContent = data.authorize_url;
+      $("orcarouter-url").hidden = false;
+    }
+    $("orcarouter-status").textContent = data.message;
+  } catch (err) {
+    if (generation !== state.attempt) return;
+    releaseLogin("Login could not be started: " + err);
+  }
+}
+
+function releaseLogin(message) {
+  state.busy = false;
+  $("orcarouter-connect").disabled = false;
+  $("orcarouter-cancel").hidden = true;
+  $("orcarouter-url").hidden = true;
+  if (message) {
+    $("orcarouter-status").textContent = message;
+  }
+}
+
+async function cancelLogin() {
+  state.attempt += 1;
+  state.generation += 1;
+  releaseLogin("Login cancelled. Your stored key was not changed.");
+  try { await fetch("/api/connect/cancel", { method: "POST" }); } catch (err) {}
+}
+
+// pagehide must clear the UI synchronously: the browser may restore this page
+// from the back-forward cache, and a guard-suppressed finally block would
+// leave it permanently busy.
+window.addEventListener("pagehide", () => {
+  state.attempt += 1;
+  state.generation += 1;
+  releaseLogin("Login was interrupted. Start it again when you are ready.");
+  try {
+    fetch("/api/connect/cancel", { method: "POST", keepalive: true });
+  } catch (err) {}
+});
+
+window.addEventListener("DOMContentLoaded", () => {
+  $("provider-select").addEventListener("change", providerChanged);
+  $("model-trigger").addEventListener("click", () => {
+    if ($("model-listbox").hidden) openPanel(); else closePanel();
+  });
+  $("attach-image").addEventListener("change", (event) => {
+    state.required = event.target.checked ? ["image"] : [];
+    renderOptions();
+    updateStatus();
+  });
+  $("catalog-refresh").addEventListener("click", refreshCatalog);
+  $("key-save").addEventListener("click", saveKey);
+  $("key-clear").addEventListener("click", clearKey);
+  $("orcarouter-connect").addEventListener("click", startLogin);
+  $("orcarouter-cancel").addEventListener("click", cancelLogin);
+  document.addEventListener("click", (event) => {
+    const wrap = document.querySelector(".selector");
+    if (wrap && !wrap.contains(event.target)) closePanel();
+  });
+  providerChanged();
+});
+"""
+
+
+def build_settings_page(icon_url: str = orcarouter.ORCAROUTER_ICON_URL) -> bytes:
+    """The OrcaRouter settings page.
+
+    Both authentication entries are visible side by side: the API-key field
+    (a password input, so the value is masked) and the PKCE connect button.
+    """
+    return f"""<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>OrcaRouter provider settings</title>
+<style>{_PAGE_CSS}</style>
+</head>
+<body>
+<main class="card">
+  <h1>
+    <img src="{icon_url}" alt="OrcaRouter" width="28" height="28"
+         onerror="this.replaceWith(orcaMark())">
+    OrcaRouter provider
+  </h1>
+
+  <fieldset>
+    <legend>Provider</legend>
+    <label for="provider-select">Model provider</label>
+    <select id="provider-select">
+      <option value="openai">OpenAI</option>
+      <option value="anthropic">Anthropic</option>
+      <option value="orcarouter" selected>OrcaRouter - API</option>
+      <option value="orcarouter_oauth">OrcaRouter - Auth</option>
+    </select>
+    <p class="hint">Two OrcaRouter entries: paste a key you already hold, or
+    sign in and let OrcaRouter issue one. Both reach the same inference API.</p>
+  </fieldset>
+
+  <fieldset id="orcarouter-panel">
+    <legend>Authentication</legend>
+
+    <label for="orcarouter-api-key">OrcaRouter API key (sk-orca-...)</label>
+    <input type="password" id="orcarouter-api-key" name="orcarouter_api_key"
+           autocomplete="off" spellcheck="false"
+           placeholder="Paste an existing sk-orca- key">
+    <div class="row">
+      <button type="button" id="key-save">Save key</button>
+      <button type="button" id="key-clear">Clear key</button>
+    </div>
+    <p class="hint">Keys live in config.json next to every other provider
+    secret. They are never logged or shown in full.</p>
+
+    <div class="row">
+      <button type="button" id="orcarouter-connect">Connect with OrcaRouter</button>
+      <button type="button" id="orcarouter-cancel" hidden>Cancel</button>
+    </div>
+    <p class="hint">OAuth 2.0 + PKCE in your browser. No client secret, no
+    redirect URI to register first.</p>
+
+    <pre id="orcarouter-url" class="hint" hidden></pre>
+    <div id="orcarouter-status" class="status" data-tone="ok">Not signed in yet.</div>
+  </fieldset>
+
+  <fieldset id="model-field">
+    <legend>Model</legend>
+    <div class="row">
+      <label style="margin:0"><input type="checkbox" id="attach-image"> Attach an image</label>
+      <button type="button" id="catalog-refresh">Refresh</button>
+    </div>
+    <div class="selector">
+      <button type="button" id="model-trigger" aria-haspopup="listbox"
+              aria-expanded="false" style="width:100%;text-align:left">Select a model</button>
+      <div id="model-listbox" role="listbox" class="panel" hidden></div>
+    </div>
+    <div id="model-empty" class="hint" hidden>No model matches the current filters.</div>
+    <div id="model-stale" class="status" data-tone="warn" hidden></div>
+    <div id="catalog-status" class="status" data-tone="ok"></div>
+  </fieldset>
+</main>
+<script>{_PAGE_JS}</script>
+</body>
+</html>
+""".encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Loopback settings server
+# ---------------------------------------------------------------------------
+
+class _SettingsHandler(BaseHTTPRequestHandler):
+    server_version = "OrcaRouterSettings/1.0"
+
+    def log_message(self, *_args: Any) -> None:  # keep the console quiet
+        return
+
+    # -- helpers ----------------------------------------------------------
+    def _send(self, status: int, body: bytes, content_type: str) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_json(self, payload: Dict[str, Any], status: int = 200) -> None:
+        self._send(status, json.dumps(payload).encode("utf-8"), "application/json")
+
+    def _read_json(self) -> Dict[str, Any]:
+        length = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(length) if length else b"{}"
+        try:
+            parsed = json.loads(raw.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+
+    # -- routes -----------------------------------------------------------
+    def do_GET(self) -> None:  # noqa: N802 - http.server API
+        parsed = urllib.parse.urlsplit(self.path)
+        if parsed.path in {"/", "/index.html"}:
+            self._send(200, build_settings_page(self.server.icon_url), "text/html; charset=utf-8")
+            return
+        if parsed.path == "/api/catalog":
+            query = urllib.parse.parse_qs(parsed.query)
+            capability = (query.get("capability") or [CAPABILITY_CHAT])[0]
+            result = self.server.service.load(capability)
+            self._send_json(self.server.service.to_json(result, capability))
+            return
+        if parsed.path == "/api/status":
+            record = OrcaRouterCredentialStore(self.server.config).load()
+            self._send_json(
+                {
+                    "has_key": record.is_set,
+                    "masked_key": record.masked(),
+                    "auth_method": record.source,
+                    "state": record.state,
+                    "auth_base": self.server.service.origins.auth_base,
+                    "api_base": self.server.service.origins.api_base,
+                }
+            )
+            return
+        self._send(404, b"not found", "text/plain; charset=utf-8")
+
+    def do_POST(self) -> None:  # noqa: N802 - http.server API
+        parsed = urllib.parse.urlsplit(self.path)
+        config = self.server.config
+
+        if parsed.path == "/api/credential":
+            payload = self._read_json()
+            key = str(payload.get("api_key", "") or "").strip()
+            try:
+                credential = orcarouter.ApiKeyCredentialSource(api_key=key).acquire()
+            except orcarouter.OrcaRouterError as exc:
+                self._send_json({"ok": False, "message": str(exc)}, status=400)
+                return
+            record = OrcaRouterCredentialStore(config).save(credential)
+            self.server.persist()
+            self._send_json(
+                {
+                    "ok": True,
+                    "message": f"Stored the API key ({record.masked()}).",
+                }
+            )
+            return
+
+        if parsed.path == "/api/credential/clear":
+            record = OrcaRouterCredentialStore(config).clear()
+            self.server.persist()
+            self._send_json(
+                {"ok": True, "message": f"Cleared the stored key (generation {record.generation})."}
+            )
+            return
+
+        if parsed.path == "/api/connect/start":
+            self._send_json(self.server.start_login())
+            return
+
+        if parsed.path == "/api/connect/cancel":
+            self.server.cancel_login()
+            self._send_json({"ok": True, "message": "Login cancelled."})
+            return
+
+        self._send(404, b"not found", "text/plain; charset=utf-8")
+
+
+class OrcaRouterSettingsServer:
+    """A loopback HTTP server hosting the OrcaRouter settings page.
+
+    It exists so the provider can be configured from a real page with a real
+    model selector, and so the PKCE loopback redirect has somewhere to land.
+    The API key is held by this process: the page only ever receives model
+    metadata and a masked key.
+    """
+
+    def __init__(
+        self,
+        config: Dict[str, Any],
+        *,
+        service: Optional[OrcaRouterCatalogService] = None,
+        connect_source_factory: Optional[
+            Callable[[OrcaRouterOrigins], orcarouter.PKCECredentialSource]
+        ] = None,
+        persist: Optional[Callable[[], Any]] = None,
+        host: str = "127.0.0.1",
+        icon_url: str = orcarouter.ORCAROUTER_ICON_URL,
+    ) -> None:
+        self.config = config
+        self.service = service or OrcaRouterCatalogService(config)
+        self.persist = persist or (lambda: None)
+        self.icon_url = icon_url
+        self._connect_source_factory = connect_source_factory
+        self._httpd = ThreadingHTTPServer((host, 0), _SettingsHandler)
+        self._httpd.config = config
+        self._httpd.service = self.service
+        self._httpd.persist = self.persist
+        self._httpd.icon_url = icon_url
+        self._httpd.start_login = self.start_login
+        self._httpd.cancel_login = self.cancel_login
+        self._thread: Optional[threading.Thread] = None
+        # Login lock and generation guard: a late response from an old
+        # attempt must never overwrite a newer login.
+        self._login_lock = threading.Lock()
+        self._login_generation = 0
+        self._pending: Optional[orcarouter.LoopbackCallback] = None
+
+    # -- lifecycle --------------------------------------------------------
+    @property
+    def port(self) -> int:
+        return int(self._httpd.server_address[1])
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def start(self) -> "OrcaRouterSettingsServer":
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    def stop(self) -> None:
+        self.cancel_login()
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+            self._thread = None
+
+    def __enter__(self) -> "OrcaRouterSettingsServer":
+        return self.start()
+
+    def __exit__(self, *_exc: Any) -> None:
+        self.stop()
+
+    # -- PKCE login -------------------------------------------------------
+    def _source(self) -> orcarouter.PKCECredentialSource:
+        if self._connect_source_factory is not None:
+            return self._connect_source_factory(self.service.origins)
+        return orcarouter.PKCECredentialSource(
+            origins=self.service.origins,
+            flow=str(self.config.get("ORCAROUTER_AUTH_FLOW", "A") or "A"),
+        )
+
+    def start_login(self) -> Dict[str, Any]:
+        """Begin a PKCE login and return the authorization URL.
+
+        Only one login may be in flight.  Starting another while one is
+        pending cancels the old attempt first, so the lock is always
+        released by whichever terminal path runs.
+        """
+        with self._login_lock:
+            self._login_generation += 1
+            generation = self._login_generation
+            self.cancel_login(lock=False)
+
+            pair = orcarouter.new_pkce_pair()
+            source = self._source()
+            if str(getattr(source, "flow", "A")).upper() == "B":
+                url = orcarouter.build_authorize_url(
+                    self.service.origins, pair, callback_url="oob"
+                )
+                return {
+                    "attempt": generation,
+                    "authorize_url": url,
+                    "message": (
+                        "Open the URL below, approve access, then paste the code "
+                        "on the command line to finish."
+                    ),
+                }
+
+            handle = orcarouter.start_loopback_listener(pair.state)
+            self._pending = handle
+            url = orcarouter.build_authorize_url(
+                self.service.origins, pair, callback_url=handle.callback_url
+            )
+            return {
+                "attempt": generation,
+                "authorize_url": url,
+                "message": (
+                    "Waiting for approval. The code returns to "
+                    f"{handle.callback_url} automatically."
+                ),
+            }
+
+    def cancel_login(self, *, lock: bool = True) -> None:
+        """Release the login lock on every terminal path."""
+        if lock:
+            with self._login_lock:
+                self._login_generation += 1
+                handle, self._pending = self._pending, None
+        else:
+            handle, self._pending = self._pending, None
+        if handle is not None:
+            handle.close()
+
+    def current_generation(self) -> int:
+        return self._login_generation
+
+
+# ---------------------------------------------------------------------------
+# Textual dashboard panel
+# ---------------------------------------------------------------------------
+
+TRANSLATIONS: Dict[str, Dict[str, str]] = {
+    "zh": {
+        "orca_title": "OrcaRouter 提供商",
+        "orca_provider": "提供商",
+        "orca_auth": "认证方式",
+        "orca_api_key": "API Key",
+        "orca_connect": "登录 OrcaRouter",
+        "orca_cancel": "取消登录",
+        "orca_model": "模型",
+        "orca_refresh": "刷新目录",
+        "orca_pick": "选择模型",
+        "orca_attach_image": "附加图片",
+    },
+    "en": {
+        "orca_title": "OrcaRouter provider",
+        "orca_provider": "Provider",
+        "orca_auth": "Authentication",
+        "orca_api_key": "API Key",
+        "orca_connect": "Connect with OrcaRouter",
+        "orca_cancel": "Cancel login",
+        "orca_model": "Model",
+        "orca_refresh": "Refresh catalog",
+        "orca_pick": "Select a model",
+        "orca_attach_image": "Attach image",
+    },
+}
+
+
+def tr(language: str, key: str) -> str:
+    """Resolve a label through the catalog, falling back to English."""
+    table = TRANSLATIONS.get(language) or TRANSLATIONS["en"]
+    return table.get(key) or TRANSLATIONS["en"][key]
+
+
+@dataclass
+class OrcaRouterPanelModel:
+    """Non-Textual core of the dashboard panel, so it stays testable."""
+
+    state: ModelSelectorState = field(default_factory=ModelSelectorState)
+    message: str = ""
+
+    def set_catalog(self, result: Optional[CatalogResult]) -> None:
+        self.state.set_catalog(result)
+        self.message = self.state.status_note()
+
+    def provider_changed(self, provider: str) -> None:
+        self.state.set_provider(provider)
+        self.message = self.state.status_note()
+
+    def attach_image(self, attached: bool) -> None:
+        if attached:
+            self.state.add_modality("image")
+        else:
+            self.state.remove_modality("image")
+        self.message = self.state.status_note()
+
+
+def build_settings_app(config: Dict[str, Any]):
+    """Build the Textual settings screen (imported lazily: textual is optional)."""
+    from textual.app import App, ComposeResult
+    from textual.containers import Horizontal, Vertical
+    from textual.screen import ModalScreen
+    from textual.widgets import Button, Input, Label, Select, Static
+
+    service = OrcaRouterCatalogService(config)
+
+    class OrcaRouterSettingsApp(ModalScreen[None]):
+        """The OrcaRouter provider panel, reachable from the dashboard."""
+
+        CSS = """
+        OrcaRouterSettingsApp { align: center middle; }
+        #orca-settings { width: 78; height: auto; max-height: 90%;
+                         border: round $accent; padding: 1 2; background: $surface; }
+        .orca-label { margin-top: 1; }
+        #orca-status { margin-top: 1; color: $text-muted; }
+        #orca-actions { height: 3; }
+        """
+
+        BINDINGS = [("escape", "dismiss", "Close")]
+
+        def __init__(self, language: str = "en") -> None:
+            super().__init__()
+            self.language = language
+            self.panel = OrcaRouterPanelModel()
+
+        def tr(self, key: str) -> str:
+            return tr(self.language, key)
+
+        def compose(self) -> ComposeResult:
+            provider_options = [
+                ("OpenAI", "openai"),
+                ("Anthropic", "anthropic"),
+                ("OrcaRouter - API", orcarouter.PROVIDER_ID),
+                ("OrcaRouter - Auth", orcarouter.PROVIDER_ID_PKCE),
+            ]
+            yield Vertical(
+                Label(self.tr("orca_title")),
+                Label(self.tr("orca_provider"), classes="orca-label"),
+                Select(provider_options, value=orcarouter.PROVIDER_ID, id="orca-provider"),
+                Label(self.tr("orca_auth"), classes="orca-label"),
+                Input(placeholder="sk-orca-...", password=True, id="orca-api-key"),
+                Horizontal(
+                    Button(self.tr("orca_api_key"), id="orca-save-key", variant="primary"),
+                    Button(self.tr("orca_connect"), id="orca-connect"),
+                    Button(self.tr("orca_cancel"), id="orca-cancel"),
+                    id="orca-actions",
+                ),
+                Label(self.tr("orca_model"), classes="orca-label"),
+                Select([], id="orca-model"),
+                Horizontal(
+                    Button(self.tr("orca_refresh"), id="orca-refresh"),
+                    id="orca-model-actions",
+                ),
+                Static("", id="orca-status"),
+                id="orca-settings",
+            )
+
+        def on_mount(self) -> None:
+            self.query_one("#orca-cancel", Button).disabled = True
+            self._refresh_catalog()
+
+        def _refresh_catalog(self) -> None:
+            self.panel.state.set_loading()
+            self._set_status(self.panel.state.status_note())
+            try:
+                result = service.load(CAPABILITY_CHAT)
+            except Exception as exc:  # keep the panel usable on any failure
+                self._set_status(f"Model discovery failed: {exc}")
+                return
+            self.panel.set_catalog(result)
+            self._render_options()
+
+        def _render_options(self) -> None:
+            options = [
+                (option.label, option.id) for option in self.panel.state.options()
+            ]
+            selector = self.query_one("#orca-model", Select)
+            selector.set_options(options)
+            if options:
+                selector.value = self.panel.state.selected or options[0][1]
+            else:
+                selector.value = Select.BLANK
+            self._set_status(self.panel.state.status_note())
+
+        def _set_status(self, message: str) -> None:
+            self.query_one("#orca-status", Static).update(message)
+
+        def on_select_changed(self, event: Any) -> None:
+            if event.select.id == "orca-provider":
+                self.panel.provider_changed(str(event.value))
+                if self.panel.state.is_orcarouter:
+                    self._refresh_catalog()
+                else:
+                    self._render_options()
+                return
+            if event.select.id == "orca-model":
+                value = event.value
+                if value is not Select.BLANK and value is not None:
+                    self.panel.state.select(str(value))
+
+        def on_button_pressed(self, event: Any) -> None:
+            if event.button.id == "orca-refresh":
+                self._refresh_catalog()
+            elif event.button.id == "orca-save-key":
+                self._save_key()
+            elif event.button.id == "orca-connect":
+                self._set_status(
+                    "Approve the login in your browser. The issued key is "
+                    "stored next to your other provider secrets."
+                )
+            elif event.button.id == "orca-cancel":
+                self._set_status("Login cancelled. Your stored key was not changed.")
+
+        def _save_key(self) -> None:
+            from core.config import save_config
+
+            raw = self.query_one("#orca-api-key", Input).value
+            try:
+                credential = orcarouter.ApiKeyCredentialSource(api_key=raw).acquire()
+            except orcarouter.OrcaRouterError as exc:
+                self._set_status(str(exc))
+                return
+            record = OrcaRouterCredentialStore(config).save(credential)
+            save_config()
+            self.query_one("#orca-api-key", Input).value = ""
+            self._set_status(f"Stored the API key ({record.masked()}).")
+            self._refresh_catalog()
+
+        def action_dismiss(self) -> None:
+            self.dismiss(None)
+
+    return OrcaRouterSettingsApp
+
+
+__all__ = [
+    "ModelSelectorState",
+    "OrcaRouterCatalogService",
+    "OrcaRouterPanelModel",
+    "OrcaRouterSettingsServer",
+    "SelectorOption",
+    "TRANSLATIONS",
+    "build_settings_app",
+    "build_settings_page",
+    "tr",
+]

--- a/sim/tui.py
+++ b/sim/tui.py
@@ -78,6 +78,7 @@ TRANSLATIONS: Dict[str, Dict[str, str]] = {
         "help_r": "清空视图",
         "help_n": "下一轮",
         "help_t": "设置目标",
+        "help_o": "OrcaRouter 设置",
         "help_browse": "滚轮 / PgUp / PgDn / ↑↓  浏览日志",
         "help_done": "调参完成，按 n 可以上次结果为起点继续新一轮",
         "setpoint_prompt": "输入新的目标值",
@@ -144,6 +145,7 @@ TRANSLATIONS: Dict[str, Dict[str, str]] = {
         "help_r": "Reset View",
         "help_n": "Next Round",
         "help_t": "Set SP",
+        "help_o": "OrcaRouter",
         "help_browse": "Wheel / PgUp / PgDn / ↑↓  browse log",
         "help_done": "Tuning done. Press n to start another round from the last result.",
         "setpoint_prompt": "Enter a new setpoint",
@@ -458,6 +460,7 @@ class PanelState:
             + hk("p", self.tr("help_p"))
             + sep
             + hk("t", self.tr("help_t"))
+            + hk("o", self.tr("help_o"))
             + sep
             + hk("l", self.tr("help_l"))
             + sep
@@ -702,6 +705,7 @@ class SimulationTUIApp(App[None]):
         ("l", "toggle_event_detail", "Log detail"),
         ("r", "reset_view", "Reset view"),
         ("n", "next_round", "Next round"),
+        ("o", "open_orcarouter_settings", "OrcaRouter"),
     ]
 
     def __init__(
@@ -976,10 +980,27 @@ class SimulationTUIApp(App[None]):
         self._log_requires_full_refresh = True
         self._refresh_all()
 
+    def action_open_orcarouter_settings(self) -> None:
+        """Open the OrcaRouter provider panel (API key and PKCE entries)."""
+        from core.config import CONFIG
+        from sim.orcarouter_gui import build_settings_app
+
+        try:
+            settings_screen = build_settings_app(CONFIG)(self.state.language)
+        except Exception as exc:  # keep the dashboard usable
+            self.state.apply_event(
+                {
+                    "type": EVENT_LOG,
+                    "label": "orca",
+                    "message": f"[WARN] OrcaRouter settings unavailable: {exc}",
+                }
+            )
+            return
+        self.push_screen(settings_screen)
+
     def action_change_setpoint(self) -> None:
         if self.state.tuning_done or not self._worker_is_running():
             return
-
         def on_setpoint(value: Optional[float]) -> None:
             if value is None:
                 return

--- a/tests/test_orcarouter_gui.py
+++ b/tests/test_orcarouter_gui.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Tests for the OrcaRouter settings surface: the loopback settings server, the
+catalog service's key boundary, the login lock, and locale parity.
+"""
+
+import json
+import sys
+import unittest
+import urllib.request
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from llm import orcarouter
+from llm.orcarouter import (
+    CAPABILITY_CHAT,
+    CatalogResult,
+    ModelInfo,
+    OrcaRouterCredential,
+)
+from sim import orcarouter_gui
+from sim.orcarouter_gui import (
+    ModelSelectorState,
+    OrcaRouterCatalogService,
+    OrcaRouterPanelModel,
+    OrcaRouterSettingsServer,
+)
+
+FAKE_KEY = "sk-orca-gui-0000000000000000"
+
+RECORDS = [
+    {
+        "id": "openai/gpt-5.5",
+        "name": "OpenAI: GPT-5.5",
+        "supported_endpoint_types": ["openai", "openai-response"],
+        "architecture": {"input_modalities": ["text", "image"]},
+        "context_length": 1_000_000,
+    },
+    {
+        "id": "deepseek/deepseek-v4-pro",
+        "name": "DeepSeek V4 Pro",
+        "supported_endpoint_types": ["openai"],
+        "architecture": {"input_modalities": ["text"]},
+    },
+    {
+        "id": "google/imagen-4.0-generate-001",
+        "supported_endpoint_types": ["image-generation"],
+    },
+]
+
+
+def build_live_catalog():
+    """A CatalogResult straight from the fixture records (no fetcher signature)."""
+    models = [
+        model
+        for model in (orcarouter.parse_model_record(record) for record in RECORDS)
+        if model
+    ]
+    return CatalogResult(models=models, source="live", degraded=False)
+
+
+def live_catalog(credential, origins, capability=CAPABILITY_CHAT, **kwargs):
+    models = [
+        model
+        for model in (orcarouter.parse_model_record(record) for record in RECORDS)
+        if model
+    ]
+    return CatalogResult(models=models, source="live", degraded=False)
+
+
+class CatalogServiceTests(unittest.TestCase):
+    def test_browser_payload_carries_no_credential(self):
+        config = {"ORCAROUTER_API_KEY": FAKE_KEY, "ORCAROUTER_CREDENTIAL_GENERATION": 1}
+        service = OrcaRouterCatalogService(config, fetcher=live_catalog)
+        result = service.load(CAPABILITY_CHAT)
+        payload = service.to_json(result, CAPABILITY_CHAT)
+        encoded = json.dumps(payload)
+        self.assertNotIn(FAKE_KEY, encoded)
+        ids = [model["id"] for model in payload["models"]]
+        self.assertIn("openai/gpt-5.5", ids)
+        self.assertNotIn("google/imagen-4.0-generate-001", ids)
+
+    def test_last_known_good_is_kept_after_a_failure(self):
+        config = {"ORCAROUTER_API_KEY": FAKE_KEY, "ORCAROUTER_CREDENTIAL_GENERATION": 1}
+        service = OrcaRouterCatalogService(config, fetcher=live_catalog)
+        service.load(CAPABILITY_CHAT)
+
+        def failing(credential, origins, capability=CAPABILITY_CHAT,
+                    last_known_good=None, **kwargs):
+            return CatalogResult(
+                models=list(last_known_good or orcarouter.fallback_catalog()),
+                source="last_known_good" if last_known_good else "fallback",
+                degraded=True,
+                error="network down",
+            )
+
+        service._fetcher = failing
+        result = service.load(CAPABILITY_CHAT)
+        self.assertTrue(result.degraded)
+        self.assertEqual(result.source, "last_known_good")
+        self.assertIn("openai/gpt-5.5", result.id_set())
+
+    def test_service_uses_the_api_origin_not_the_auth_origin(self):
+        service = OrcaRouterCatalogService({"ORCAROUTER_API_KEY": FAKE_KEY})
+        self.assertEqual(
+            service.origins.models_url, "https://api.orcarouter.ai/v1/models"
+        )
+        self.assertEqual(service.origins.auth_base, "https://www.orcarouter.ai")
+
+
+class SettingsPageTests(unittest.TestCase):
+    def setUp(self):
+        self.config = {
+            "ORCAROUTER_API_KEY": FAKE_KEY,
+            "ORCAROUTER_CREDENTIAL_GENERATION": 1,
+            "ORCAROUTER_AUTH_STATE": "ok",
+        }
+        service = OrcaRouterCatalogService(self.config, fetcher=live_catalog)
+        self.server = OrcaRouterSettingsServer(self.config, service=service).start()
+        self.addCleanup(self.server.stop)
+
+    def _get(self, path):
+        return urllib.request.urlopen(self.server.base_url + path, timeout=10)
+
+    def _post(self, path, payload=None):
+        data = json.dumps(payload or {}).encode("utf-8")
+        request = urllib.request.Request(
+            self.server.base_url + path,
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        return urllib.request.urlopen(request, timeout=10)
+
+    def test_page_shows_both_authentication_entries(self):
+        html = self._get("/").read().decode("utf-8")
+        # API-key entry, masked.
+        self.assertIn('id="orcarouter-api-key"', html)
+        self.assertIn('type="password"', html)
+        self.assertIn("Save key", html)
+        self.assertIn("Clear key", html)
+        # PKCE entry, side by side with it.
+        self.assertIn("Connect with OrcaRouter", html)
+        self.assertIn('id="orcarouter-connect"', html)
+        self.assertIn("OAuth 2.0 + PKCE", html)
+
+    def test_page_offers_a_real_listbox_not_a_free_text_field(self):
+        html = self._get("/").read().decode("utf-8")
+        self.assertIn('role="listbox"', html)
+        self.assertIn('aria-haspopup="listbox"', html)
+        self.assertIn('aria-expanded="false"', html)
+        self.assertIn('id="model-trigger"', html)
+        # The model control is a button + listbox, never an editable input.
+        self.assertNotIn('id="model-input"', html)
+        self.assertIn(orcarouter.ORCAROUTER_ICON_URL, html)
+
+    def test_page_never_contains_the_stored_key(self):
+        html = self._get("/").read().decode("utf-8")
+        self.assertNotIn(FAKE_KEY, html)
+
+    def test_pagehide_clears_busy_state_and_cancels_on_the_server(self):
+        html = self._get("/").read().decode("utf-8")
+        self.assertIn('addEventListener("pagehide"', html)
+        self.assertIn("keepalive: true", html)
+        self.assertIn("/api/connect/cancel", html)
+        # The handler must release the UI synchronously, not via a guarded
+        # finally block that a stale generation would suppress.
+        self.assertIn("releaseLogin(", html)
+
+    def test_status_endpoint_reports_a_masked_key_only(self):
+        payload = json.loads(self._get("/api/status").read().decode("utf-8"))
+        self.assertTrue(payload["has_key"])
+        self.assertNotIn(FAKE_KEY, json.dumps(payload))
+        self.assertEqual(payload["api_base"], "https://api.orcarouter.ai/v1")
+
+    def test_catalog_endpoint_returns_filtered_models_without_the_key(self):
+        body = self._get("/api/catalog?capability=chat").read().decode("utf-8")
+        payload = json.loads(body)
+        self.assertNotIn(FAKE_KEY, body)
+        self.assertEqual(payload["capability"], "chat")
+        self.assertFalse(payload["degraded"])
+        ids = [model["id"] for model in payload["models"]]
+        self.assertEqual(ids, ["openai/gpt-5.5", "deepseek/deepseek-v4-pro"])
+
+    def test_saving_and_clearing_a_key_goes_through_the_shared_store(self):
+        saved = json.loads(
+            self._post("/api/credential", {"api_key": "sk-orca-gui-2222"}).read()
+        )
+        self.assertTrue(saved["ok"])
+        self.assertEqual(self.config["ORCAROUTER_API_KEY"], "sk-orca-gui-2222")
+        self.assertNotIn("sk-orca-gui-2222", json.dumps(saved))
+        self.assertGreater(self.config["ORCAROUTER_CREDENTIAL_GENERATION"], 1)
+
+        cleared = json.loads(self._post("/api/credential/clear").read())
+        self.assertTrue(cleared["ok"])
+        self.assertEqual(self.config["ORCAROUTER_API_KEY"], "")
+
+    def test_an_empty_key_is_refused_with_an_actionable_message(self):
+        try:
+            self._post("/api/credential", {"api_key": ""})
+        except urllib.error.HTTPError as exc:
+            self.assertEqual(exc.code, 400)
+            payload = json.loads(exc.read().decode("utf-8"))
+        else:
+            self.fail("an empty key should be refused")
+        self.assertFalse(payload["ok"])
+
+    def test_connect_start_points_at_the_auth_origin(self):
+        payload = json.loads(self._post("/api/connect/start").read())
+        self.assertTrue(payload["authorize_url"].startswith("https://www.orcarouter.ai/auth?"))
+        self.assertNotIn("api.orcarouter.ai", payload["authorize_url"])
+        self.assertIn("code_challenge_method=S256", payload["authorize_url"])
+
+    def test_connect_lock_is_released_by_cancel_and_a_new_login_can_start(self):
+        first = json.loads(self._post("/api/connect/start").read())
+        self._post("/api/connect/cancel")
+        # Without a remount, a second login starts cleanly.
+        second = json.loads(self._post("/api/connect/start").read())
+        self.assertGreater(second["attempt"], first["attempt"])
+        self.assertNotEqual(second["authorize_url"], first["authorize_url"])
+
+    def test_starting_a_login_twice_does_not_strand_the_old_listener(self):
+        self._post("/api/connect/start")
+        pending = self.server._pending
+        self.assertIsNotNone(pending)
+        self._post("/api/connect/start")
+        self.assertIsNot(self.server._pending, pending)
+
+    def test_manual_cancel_releases_the_lock(self):
+        self._post("/api/connect/start")
+        generation = self.server.current_generation()
+        self.server.cancel_login()
+        self.assertGreater(self.server.current_generation(), generation)
+        self.assertIsNone(self.server._pending)
+
+
+class PanelModelTests(unittest.TestCase):
+    def test_provider_switch_recomputes_options(self):
+        panel = OrcaRouterPanelModel()
+        panel.set_catalog(build_live_catalog())
+        self.assertEqual(
+            panel.state.option_ids(),
+            ["openai/gpt-5.5", "deepseek/deepseek-v4-pro"],
+        )
+        panel.provider_changed("openai")
+        self.assertEqual(panel.state.option_ids(), [])
+
+    def test_attach_image_narrows_the_option_list(self):
+        panel = OrcaRouterPanelModel()
+        panel.set_catalog(build_live_catalog())
+        panel.attach_image(True)
+        self.assertEqual(panel.state.option_ids(), ["openai/gpt-5.5"])
+        panel.attach_image(False)
+        self.assertEqual(len(panel.state.option_ids()), 2)
+
+
+class LocaleParityTests(unittest.TestCase):
+    def test_every_locale_defines_every_orcarouter_label(self):
+        catalogs = orcarouter_gui.TRANSLATIONS
+        self.assertIn("en", catalogs)
+        self.assertIn("zh", catalogs)
+        reference = set(catalogs["en"])
+        for language, table in catalogs.items():
+            self.assertEqual(
+                set(table), reference, f"{language} is missing OrcaRouter labels"
+            )
+            for key, value in table.items():
+                self.assertTrue(value.strip(), f"{language}.{key} is empty")
+
+    def test_unknown_locale_falls_back_to_english(self):
+        self.assertEqual(
+            orcarouter_gui.tr("de", "orca_connect"),
+            orcarouter_gui.TRANSLATIONS["en"]["orca_connect"],
+        )
+
+    def test_both_auth_labels_are_distinct_in_every_locale(self):
+        for language, table in orcarouter_gui.TRANSLATIONS.items():
+            self.assertNotEqual(
+                table["orca_api_key"], table["orca_connect"], language
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_orcarouter_provider.py
+++ b/tests/test_orcarouter_provider.py
@@ -1,0 +1,979 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Regression tests for the OrcaRouter provider: the two authentication entry
+points, the credential lifecycle, the model catalog, and the selector.
+
+Every credential in here is a fabricated test value.  The tests assert that
+those values never reach a URL, a log line, or an error message.
+"""
+
+import json
+import sys
+import unittest
+import urllib.error
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from core.doctoring import models_endpoint
+from llm import orcarouter
+from llm.client import LLMTuner
+from llm.orcarouter import (
+    CAPABILITY_CHAT,
+    CAPABILITY_EMBEDDING,
+    CAPABILITY_IMAGE,
+    CAPABILITY_RERANK,
+    CAPABILITY_VIDEO,
+    CatalogResult,
+    ModelInfo,
+    OrcaRouterCredential,
+    OrcaRouterCredentialStore,
+    OrcaRouterError,
+    OrcaRouterPKCEError,
+    PROVIDER_ID,
+    PROVIDER_ID_PKCE,
+    REAUTH_NEEDED,
+)
+
+FAKE_KEY = "sk-orca-test-0000000000000000"
+FAKE_KEY_ALT = "sk-orca-test-1111111111111111"
+FAKE_CODE = "test-auth-code-abc"
+
+
+class FakeConfig(dict):
+    """A stand-in for the project CONFIG mapping."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+def fake_fetch(payload, status=200):
+    """Build a urllib-style opener returning ``payload`` as JSON."""
+
+    class Response:
+        def __init__(self, body):
+            self._body = body
+            self.status = status
+
+        def read(self, _n=-1):
+            return self._body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return None
+
+    def opener(request, timeout=None):
+        if status >= 400:
+            raise urllib.error.HTTPError(
+                request.full_url, status, "err", {}, None
+            )
+        return Response(json.dumps(payload).encode("utf-8"))
+
+    return opener
+
+
+def catalog_payload(records):
+    return {"data": records}
+
+
+TEXT_MODEL = {
+    "id": "openai/gpt-5.5",
+    "name": "OpenAI: GPT-5.5",
+    "supported_endpoint_types": ["openai", "openai-response"],
+    "context_length": 1_000_000,
+    "architecture": {"input_modalities": ["file", "image", "text"]},
+    "reasoning_efforts": ["low", "medium", "high", "xhigh"],
+}
+TEXT_ONLY_MODEL = {
+    "id": "deepseek/deepseek-v4-pro",
+    "name": "DeepSeek V4 Pro",
+    "supported_endpoint_types": ["openai", "openai-response"],
+    "context_length": 1_048_576,
+    "architecture": {"input_modalities": ["text"]},
+}
+IMAGE_GEN_MODEL = {
+    "id": "google/imagen-4.0-generate-001",
+    "supported_endpoint_types": ["image-generation"],
+    "architecture": {"input_modalities": ["text"]},
+}
+EMBEDDING_MODEL = {
+    "id": "google/gemini-embedding-001",
+    "supported_endpoint_types": ["embeddings"],
+}
+VIDEO_MODEL = {
+    "id": "openai/sora-2",
+    "supported_endpoint_types": ["openai-video"],
+}
+RERANK_MODEL = {
+    "id": "jina/jina-reranker-v3",
+    "supported_endpoint_types": ["jina-rerank"],
+}
+NO_ENDPOINT_MODEL = {"id": "claude-opus-4-6", "name": "Claude Opus 4.6",
+                     "architecture": {"input_modalities": ["text"]}}
+
+ALL_RECORDS = [
+    TEXT_MODEL,
+    TEXT_ONLY_MODEL,
+    IMAGE_GEN_MODEL,
+    EMBEDDING_MODEL,
+    VIDEO_MODEL,
+    RERANK_MODEL,
+    NO_ENDPOINT_MODEL,
+]
+
+
+# ---------------------------------------------------------------------------
+# Origins
+# ---------------------------------------------------------------------------
+
+class OriginTests(unittest.TestCase):
+    def test_public_defaults_are_separate_origins(self):
+        origins = orcarouter.resolve_origins({}, environ={})
+        self.assertEqual(origins.auth_base, "https://www.orcarouter.ai")
+        self.assertEqual(origins.api_base, "https://api.orcarouter.ai/v1")
+        self.assertEqual(origins.authorize_url, "https://www.orcarouter.ai/auth")
+        self.assertEqual(
+            origins.exchange_url, "https://www.orcarouter.ai/api/v1/auth/keys"
+        )
+        self.assertEqual(
+            origins.models_url, "https://api.orcarouter.ai/v1/models"
+        )
+
+    def test_exchange_path_is_not_the_relay_auth_path(self):
+        """The relay is at /v1; auth endpoints are not. This one 404s."""
+        self.assertNotEqual(orcarouter.EXCHANGE_PATH, "/v1/auth/keys")
+        self.assertFalse(orcarouter.EXCHANGE_PATH.startswith("/v1/"))
+        self.assertEqual(orcarouter.EXCHANGE_PATH, "/api/v1/auth/keys")
+
+    def test_explicit_overrides_win_over_shared_base(self):
+        origins = orcarouter.resolve_origins(
+            {"ORCAROUTER_API_BASE_URL": "https://api.selfhosted.example.com"},
+            environ={
+                "ORCA_BASE_URL": "https://shared.example.com",
+                "ORCA_AUTH_BASE_URL": "https://auth.example.com",
+            },
+        )
+        # The dedicated auth override beats the shared base...
+        self.assertEqual(origins.auth_base, "https://auth.example.com")
+        # ...and the dedicated API override beats it for inference, with /v1
+        # appended to the API origin only - never derived from the auth origin.
+        self.assertEqual(origins.api_base, "https://api.selfhosted.example.com/v1")
+        self.assertNotIn("shared.example.com", origins.api_base)
+
+    def test_shared_base_supplies_both_origins(self):
+        origins = orcarouter.resolve_origins(
+            {}, environ={"ORCA_BASE_URL": "https://one.example.com"}
+        )
+        self.assertEqual(origins.auth_base, "https://one.example.com")
+        self.assertEqual(origins.api_base, "https://one.example.com/v1")
+
+    def test_http_is_rejected_for_remote_hosts(self):
+        with self.assertRaises(OrcaRouterError):
+            orcarouter.resolve_origins(
+                {}, environ={"ORCA_API_BASE_URL": "http://api.example.com"}
+            )
+
+    def test_http_is_allowed_for_loopback_dev(self):
+        origins = orcarouter.resolve_origins(
+            {}, environ={"ORCA_AUTH_BASE_URL": "http://127.0.0.1:8123"}
+        )
+        self.assertEqual(origins.auth_base, "http://127.0.0.1:8123")
+
+
+# ---------------------------------------------------------------------------
+# PKCE primitives
+# ---------------------------------------------------------------------------
+
+class PKCETests(unittest.TestCase):
+    def test_verifier_and_state_are_fresh_and_random_per_attempt(self):
+        first = orcarouter.new_pkce_pair()
+        second = orcarouter.new_pkce_pair()
+        self.assertNotEqual(first.verifier, second.verifier)
+        self.assertNotEqual(first.state, second.state)
+        # 32 random bytes -> 43 base64url characters, no padding.
+        self.assertEqual(len(first.verifier), 43)
+        self.assertNotIn("=", first.verifier)
+        self.assertNotIn("=", first.challenge)
+
+    def test_challenge_is_s256_of_the_verifier_without_padding(self):
+        import base64
+        import hashlib
+
+        pair = orcarouter.new_pkce_pair()
+        expected = (
+            base64.urlsafe_b64encode(
+                hashlib.sha256(pair.verifier.encode("ascii")).digest()
+            )
+            .decode("ascii")
+            .rstrip("=")
+        )
+        self.assertEqual(pair.challenge, expected)
+
+    def test_authorize_url_uses_auth_origin_and_carries_no_verifier(self):
+        origins = orcarouter.resolve_origins({}, environ={})
+        pair = orcarouter.new_pkce_pair()
+        url = orcarouter.build_authorize_url(
+            origins, pair, callback_url="http://127.0.0.1:51234/cb"
+        )
+        parsed = urllib.parse.urlsplit(url)
+        self.assertEqual(parsed.netloc, "www.orcarouter.ai")
+        self.assertEqual(parsed.path, "/auth")
+        query = urllib.parse.parse_qs(parsed.query)
+        self.assertEqual(query["code_challenge"], [pair.challenge])
+        self.assertEqual(query["code_challenge_method"], ["S256"])
+        self.assertEqual(query["state"], [pair.state])
+        self.assertEqual(query["scope"], ["api"])
+        # The verifier must never ride on a URL.
+        self.assertNotIn(pair.verifier, url)
+
+    def test_pkce_pair_repr_hides_the_verifier(self):
+        pair = orcarouter.new_pkce_pair()
+        self.assertNotIn(pair.verifier, repr(pair))
+        self.assertNotIn(pair.verifier, str(pair))
+
+    def test_authorize_url_rejects_a_non_loopback_http_callback(self):
+        with self.assertRaises(OrcaRouterPKCEError):
+            orcarouter.validate_callback_url("http://evil.example.com/cb")
+
+    def test_authorize_url_accepts_oob(self):
+        self.assertEqual(orcarouter.validate_callback_url("oob"), "oob")
+
+
+# ---------------------------------------------------------------------------
+# Exchange
+# ---------------------------------------------------------------------------
+
+class ExchangeTests(unittest.TestCase):
+    def setUp(self):
+        self.origins = orcarouter.resolve_origins({}, environ={})
+        self.pair = orcarouter.new_pkce_pair()
+        self.calls = []
+
+        def opener(request, timeout=None):
+            self.calls.append(request)
+            return fake_fetch(
+                {"key": FAKE_KEY, "user_id": "12345", "scope": "api"}
+            )(request, timeout)
+
+        self.opener = opener
+
+    def test_exchange_posts_to_the_auth_origin_keys_path(self):
+        result = orcarouter.exchange_code(
+            self.origins, self.pair, FAKE_CODE, opener=self.opener
+        )
+        self.assertEqual(result.key, FAKE_KEY)
+        self.assertEqual(result.scope, "api")
+        self.assertTrue(result.scope_is_usable)
+        request = self.calls[0]
+        self.assertEqual(
+            request.full_url, "https://www.orcarouter.ai/api/v1/auth/keys"
+        )
+        self.assertEqual(request.get_method(), "POST")
+
+    def test_exchange_body_carries_the_verifier_and_s256(self):
+        orcarouter.exchange_code(
+            self.origins, self.pair, FAKE_CODE, opener=self.opener
+        )
+        body = json.loads(self.calls[0].data.decode("utf-8"))
+        self.assertEqual(body["code"], FAKE_CODE)
+        self.assertEqual(body["code_verifier"], self.pair.verifier)
+        self.assertEqual(body["code_challenge_method"], "S256")
+
+    def test_scope_downgrade_is_reported_not_assumed(self):
+        def opener(request, timeout=None):
+            return fake_fetch(
+                {"key": FAKE_KEY, "user_id": "1", "scope": "read"}
+            )(request, timeout)
+
+        result = orcarouter.exchange_code(
+            self.origins, self.pair, FAKE_CODE, opener=opener
+        )
+        self.assertFalse(result.scope_is_usable)
+
+    def test_rejected_code_is_terminal_and_leaks_nothing(self):
+        def opener(request, timeout=None):
+            return fake_fetch({}, status=403)(request, timeout)
+
+        with self.assertRaises(OrcaRouterPKCEError) as ctx:
+            orcarouter.exchange_code(
+                self.origins, self.pair, FAKE_CODE, opener=opener
+            )
+        message = str(ctx.exception)
+        self.assertNotIn(self.pair.verifier, message)
+        self.assertNotIn(FAKE_CODE, message)
+
+    def test_challenge_method_downgrade_is_reported(self):
+        def opener(request, timeout=None):
+            return fake_fetch({}, status=400)(request, timeout)
+
+        with self.assertRaises(OrcaRouterPKCEError):
+            orcarouter.exchange_code(
+                self.origins, self.pair, FAKE_CODE, opener=opener
+            )
+
+    def test_rate_limited_login_is_explained(self):
+        def opener(request, timeout=None):
+            return fake_fetch({}, status=429)(request, timeout)
+
+        with self.assertRaises(OrcaRouterPKCEError) as ctx:
+            orcarouter.exchange_code(
+                self.origins, self.pair, FAKE_CODE, opener=opener
+            )
+        self.assertIn("429", str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# Flow A end to end against a local fake auth server
+# ---------------------------------------------------------------------------
+
+class FakeAuthHandler(BaseHTTPRequestHandler):
+    """A local stand-in for the OrcaRouter auth origin."""
+
+    def log_message(self, *_args):
+        return
+
+    def do_POST(self):  # noqa: N802 - http.server API
+        length = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(length) if length else b"{}"
+        body = json.loads(raw.decode("utf-8"))
+        type(self).seen.append({"path": self.path, "body": body})
+        payload = {"key": FAKE_KEY, "user_id": "12345", "scope": "api"}
+        encoded = json.dumps(payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+
+class FlowATests(unittest.TestCase):
+    """authorize -> callback -> exchange -> persist through the real adapter."""
+
+    def setUp(self):
+        FakeAuthHandler.seen = []
+        self.httpd = ThreadingHTTPServer(("127.0.0.1", 0), FakeAuthHandler)
+        self.thread = Thread(target=self.httpd.serve_forever, daemon=True)
+        self.thread.start()
+        self.auth_base = f"http://127.0.0.1:{self.httpd.server_address[1]}"
+        self.origins = orcarouter.OrcaRouterOrigins(
+            auth_base=self.auth_base, api_base=self.auth_base + "/v1"
+        )
+        self.opened = []
+
+    def tearDown(self):
+        self.httpd.shutdown()
+        self.httpd.server_close()
+
+    def _source(self):
+        """A PKCE source whose 'browser' completes the loopback redirect."""
+        source = orcarouter.PKCECredentialSource(
+            origins=self.origins, flow="A", timeout=5.0
+        )
+
+        def open_browser(url):
+            import urllib.request
+
+            self.opened.append(url)
+            parsed = urllib.parse.urlsplit(url)
+            query = urllib.parse.parse_qs(parsed.query)
+            callback = query["callback_url"][0]
+            # The fake consent screen redirects straight back with the code.
+            redirect = (
+                f"{callback}?code={FAKE_CODE}&state={query['state'][0]}"
+            )
+
+            def hit():
+                urllib.request.urlopen(redirect, timeout=5).read()
+
+            Thread(target=hit, daemon=True).start()
+            return True
+
+        source.open_browser = open_browser
+        return source
+
+    def test_full_flow_acquires_and_the_verifier_stays_private(self):
+        source = self._source()
+        credential = source.acquire()
+        self.assertEqual(credential.api_key, FAKE_KEY)
+        self.assertEqual(credential.source, "pkce")
+
+        # The authorize URL went to the auth origin and carried no verifier.
+        self.assertEqual(len(self.opened), 1)
+        self.assertTrue(self.opened[0].startswith(self.auth_base + "/auth?"))
+
+        # The exchange went to the auth origin's keys path, with S256.
+        seen = FakeAuthHandler.seen
+        self.assertEqual(len(seen), 1)
+        self.assertEqual(seen[0]["path"], "/api/v1/auth/keys")
+        self.assertEqual(seen[0]["body"]["code"], FAKE_CODE)
+        self.assertEqual(seen[0]["body"]["code_challenge_method"], "S256")
+        verifier = seen[0]["body"]["code_verifier"]
+        self.assertTrue(verifier)
+        # The verifier left the process exactly once: on the exchange.
+        self.assertNotIn(verifier, self.opened[0])
+        self.assertNotIn(verifier, str(credential))
+
+    def test_state_mismatch_never_reaches_the_exchange(self):
+        source = self._source()
+
+        def open_browser(url):
+            query = urllib.parse.parse_qs(urllib.parse.urlsplit(url).query)
+            callback = query["callback_url"][0]
+            redirect = f"{callback}?code={FAKE_CODE}&state=wrong-state"
+
+            def hit():
+                urllib.request.urlopen(redirect, timeout=5).read()
+
+            Thread(target=hit, daemon=True).start()
+            return True
+
+        source.open_browser = open_browser
+        with self.assertRaises(OrcaRouterPKCEError) as ctx:
+            source.acquire()
+        self.assertIn("state", str(ctx.exception).lower())
+        self.assertEqual(FakeAuthHandler.seen, [])
+
+    def test_denial_is_reported_and_does_not_hang(self):
+        source = self._source()
+
+        def open_browser(url):
+            query = urllib.parse.parse_qs(urllib.parse.urlsplit(url).query)
+            callback = query["callback_url"][0]
+            redirect = (
+                f"{callback}?error=access_denied&state={query['state'][0]}"
+            )
+
+            def hit():
+                urllib.request.urlopen(redirect, timeout=5).read()
+
+            Thread(target=hit, daemon=True).start()
+            return True
+
+        source.open_browser = open_browser
+        with self.assertRaises(OrcaRouterPKCEError) as ctx:
+            source.acquire()
+        self.assertIn("access_denied", str(ctx.exception))
+        self.assertEqual(FakeAuthHandler.seen, [])
+
+    def test_timeout_is_terminal(self):
+        source = orcarouter.PKCECredentialSource(
+            origins=self.origins, flow="A", timeout=0.4
+        )
+        source.open_browser = lambda _url: True  # nobody ever redirects
+        with self.assertRaises(OrcaRouterPKCEError) as ctx:
+            source.acquire()
+        self.assertIn("timed out", str(ctx.exception))
+        self.assertEqual(FakeAuthHandler.seen, [])
+
+    def test_flow_b_requires_s256_and_pastes_the_code(self):
+        source = orcarouter.PKCECredentialSource(
+            origins=self.origins, flow="B", timeout=5.0
+        )
+        opened = []
+        source.open_browser = lambda url: opened.append(url) or True
+        source.prompt_for_code = lambda: FAKE_CODE
+        credential = source.acquire()
+        self.assertEqual(credential.api_key, FAKE_KEY)
+        query = urllib.parse.parse_qs(urllib.parse.urlsplit(opened[0]).query)
+        self.assertEqual(query["callback_url"], ["oob"])
+        self.assertEqual(query["code_challenge_method"], ["S256"])
+        self.assertEqual(FakeAuthHandler.seen[0]["body"]["code"], FAKE_CODE)
+
+
+# ---------------------------------------------------------------------------
+# Credential seam: two adapters, one credential shape
+# ---------------------------------------------------------------------------
+
+class CredentialSeamTests(unittest.TestCase):
+    def setUp(self):
+        FakeAuthHandler.seen = []
+        self.httpd = ThreadingHTTPServer(("127.0.0.1", 0), FakeAuthHandler)
+        self.thread = Thread(target=self.httpd.serve_forever, daemon=True)
+        self.thread.start()
+        self.auth_base = f"http://127.0.0.1:{self.httpd.server_address[1]}"
+
+    def tearDown(self):
+        self.httpd.shutdown()
+        self.httpd.server_close()
+
+    def test_api_key_adapter_yields_the_shared_credential_shape(self):
+        registry = orcarouter.provider_registry()
+        self.assertEqual({item["id"] for item in registry}, {PROVIDER_ID, PROVIDER_ID_PKCE})
+        for item in registry:
+            self.assertEqual(item["icon"], orcarouter.ORCAROUTER_ICON_URL)
+
+    def test_both_adapters_produce_an_equivalent_credential(self):
+        key_source = orcarouter.ApiKeyCredentialSource(api_key=FAKE_KEY)
+        origins = orcarouter.resolve_origins({}, environ={})
+
+        pkce_source = orcarouter.PKCECredentialSource(
+            origins=origins, flow="B", timeout=5.0
+        )
+        opened = []
+        pkce_source.open_browser = lambda url: opened.append(url) or True
+        pkce_source.prompt_for_code = lambda: FAKE_CODE
+
+        # Drive Flow B against a local fake auth origin instead of the network.
+        pkce_source.origins = orcarouter.OrcaRouterOrigins(
+            auth_base=self.auth_base, api_base=self.auth_base + "/v1"
+        )
+
+        from_api = key_source.acquire()
+        from_pkce = pkce_source.acquire()
+
+        self.assertIsInstance(from_api, OrcaRouterCredential)
+        self.assertIsInstance(from_pkce, OrcaRouterCredential)
+        self.assertEqual(type(from_api), type(from_pkce))
+        # Same downstream shape; the source tag is the only difference.
+        self.assertEqual(
+            set(from_api.__dataclass_fields__), set(from_pkce.__dataclass_fields__)
+        )
+        self.assertEqual(from_api.source, "api_key")
+        self.assertEqual(from_pkce.source, "pkce")
+        self.assertEqual(from_api.api_key, from_pkce.api_key)
+        # The PKCE adapter used the auth origin for the shown code.
+        query = urllib.parse.parse_qs(urllib.parse.urlsplit(opened[0]).query)
+        self.assertEqual(query["callback_url"], ["oob"])
+        self.assertTrue(self.auth_base in opened[0])
+
+    def test_api_key_adapter_warns_but_does_not_reject_a_bad_prefix(self):
+        hints = []
+        orcarouter.ApiKeyCredentialSource(api_key="not-a-real-key-0000").acquire(
+            on_hint=hints.append
+        )
+        self.assertTrue(hints)
+
+    def test_api_key_adapter_refuses_an_empty_key(self):
+        with self.assertRaises(OrcaRouterError):
+            orcarouter.ApiKeyCredentialSource(api_key="  ").acquire()
+
+    def test_credential_masking_hides_the_middle(self):
+        credential = OrcaRouterCredential(api_key=FAKE_KEY, source="api_key")
+        masked = credential.masked()
+        self.assertNotEqual(masked, FAKE_KEY)
+        self.assertNotIn(FAKE_KEY[4:-4], masked)
+        self.assertFalse(OrcaRouterCredential(api_key="", source="").is_set)
+
+    def test_store_reads_the_generic_key_slot_for_compatibility(self):
+        config = FakeConfig(LLM_API_KEY=FAKE_KEY, LLM_PROVIDER=PROVIDER_ID)
+        self.assertEqual(orcarouter.effective_api_key(config), FAKE_KEY)
+
+    def test_dedicated_key_slot_wins_over_the_generic_slot(self):
+        config = FakeConfig(LLM_API_KEY=FAKE_KEY_ALT, ORCAROUTER_API_KEY=FAKE_KEY)
+        self.assertEqual(orcarouter.effective_api_key(config), FAKE_KEY)
+
+
+# ---------------------------------------------------------------------------
+# Credential lifecycle
+# ---------------------------------------------------------------------------
+
+class CredentialLifecycleTests(unittest.TestCase):
+    def setUp(self):
+        self.config = FakeConfig()
+
+    def _store(self):
+        return OrcaRouterCredentialStore(self.config)
+
+    def test_save_read_clear_round_trip(self):
+        store = self._store()
+        store.save(OrcaRouterCredential(api_key=FAKE_KEY, source="api_key"))
+        self.assertEqual(store.load().api_key, FAKE_KEY)
+
+        store.clear()
+        self.assertFalse(store.load().is_set)
+        self.assertEqual(self.config["ORCAROUTER_API_KEY"], "")
+
+    def test_save_bumps_the_generation(self):
+        store = self._store()
+        first = store.save(OrcaRouterCredential(api_key=FAKE_KEY, source="api_key"))
+        second = store.save(OrcaRouterCredential(api_key=FAKE_KEY_ALT, source="pkce"))
+        self.assertGreater(second.generation, first.generation)
+
+    def test_401_marks_only_the_rejected_generation(self):
+        store = self._store()
+        rejected = store.save(
+            OrcaRouterCredential(api_key=FAKE_KEY, source="api_key")
+        )
+        self.assertTrue(store.mark_needs_reauth(rejected.generation))
+        self.assertEqual(store.load().state, REAUTH_NEEDED)
+
+    def test_a_stale_401_cannot_poison_a_newer_credential(self):
+        store = self._store()
+        old = store.save(OrcaRouterCredential(api_key=FAKE_KEY, source="api_key"))
+        new = store.save(OrcaRouterCredential(api_key=FAKE_KEY_ALT, source="pkce"))
+
+        # A response belonging to the old generation arrives late.
+        self.assertFalse(store.mark_needs_reauth(old.generation))
+        self.assertEqual(store.load().state, orcarouter.REAUTH_OK)
+        self.assertTrue(store.load().api_key, FAKE_KEY_ALT)
+        self.assertEqual(store.load().generation, new.generation)
+
+    def test_reauth_never_deletes_the_old_secret(self):
+        store = self._store()
+        record = store.save(OrcaRouterCredential(api_key=FAKE_KEY, source="acct"))
+        store.mark_needs_reauth(record.generation)
+        # The secret is retained until a successful new login replaces it.
+        self.assertEqual(store.load().api_key, FAKE_KEY)
+
+    def test_record_masking_does_not_expose_the_key(self):
+        store = self._store()
+        record = store.save(OrcaRouterCredential(api_key=FAKE_KEY, source="api_key"))
+        self.assertNotIn(FAKE_KEY, record.masked())
+
+
+# ---------------------------------------------------------------------------
+# Provider routing
+# ---------------------------------------------------------------------------
+
+class ProviderRoutingTests(unittest.TestCase):
+    def _config(self, **overrides):
+        base = {
+            "ORCAROUTER_API_KEY": FAKE_KEY,
+            "ORCAROUTER_CREDENTIAL_GENERATION": 1,
+            "ORCAROUTER_AUTH_STATE": "ok",
+        }
+        base.update(overrides)
+        return FakeConfig(**base)
+
+    def test_orcarouter_routes_to_the_api_origin_with_bearer_auth(self):
+        from unittest.mock import patch
+
+        with patch.dict("core.config.CONFIG", self._config(), clear=True):
+            tuner = LLMTuner("", "https://api.openai.com/v1", "orcarouter/auto", PROVIDER_ID)
+        self.assertEqual(tuner.provider, "openai")
+        self.assertEqual(tuner.base_url, "https://api.orcarouter.ai/v1")
+        self.assertEqual(tuner.api_key, FAKE_KEY)
+
+    def test_pkce_id_routes_the_same_transport(self):
+        from unittest.mock import patch
+
+        with patch.dict("core.config.CONFIG", self._config(), clear=True):
+            plain = LLMTuner("", "", "orcarouter/auto", PROVIDER_ID)
+            oauth = LLMTuner("", "", "orcarouter/auto", PROVIDER_ID_PKCE)
+        self.assertEqual(plain.provider, oauth.provider)
+        self.assertEqual(plain.base_url, oauth.base_url)
+        self.assertEqual(plain.api_key, oauth.api_key)
+
+    def test_downstream_does_not_care_which_adapter_produced_the_key(self):
+        from unittest.mock import patch
+
+        api_config = self._config(ORCAROUTER_AUTH_METHOD="api_key")
+        pkce_config = self._config(ORCAROUTER_AUTH_METHOD="pkce")
+
+        with patch.dict("core.config.CONFIG", api_config, clear=True):
+            from_api = LLMTuner("", "", "orcarouter/auto", PROVIDER_ID)
+        with patch.dict("core.config.CONFIG", pkce_config, clear=True):
+            from_pkce = LLMTuner("", "", "orcarouter/auto", PROVIDER_ID_PKCE)
+
+        self.assertEqual(from_api.base_url, from_pkce.base_url)
+        self.assertEqual(from_api.model, from_pkce.model)
+        self.assertEqual(type(from_api.llm_client), type(from_pkce.llm_client))
+
+    def test_other_providers_are_untouched(self):
+        from unittest.mock import patch
+
+        with patch.dict("core.config.CONFIG", self._config(), clear=True):
+            tuner = LLMTuner(
+                "sk-real-openai", "https://api.openai.com/v1", "gpt-4o", "openai"
+            )
+        self.assertEqual(tuner.base_url, "https://api.openai.com/v1")
+        self.assertEqual(tuner.api_key, "sk-real-openai")
+        self.assertIsNone(tuner.orcarouter)
+
+    def test_missing_credential_is_reported_with_the_two_ways_to_fix_it(self):
+        from unittest.mock import patch
+
+        with patch.dict("core.config.CONFIG", FakeConfig(), clear=True):
+            with self.assertRaises(OrcaRouterError) as ctx:
+                LLMTuner("", "", "orcarouter/auto", PROVIDER_ID)
+        message = str(ctx.exception)
+        self.assertIn("ORCAROUTER_API_KEY", message)
+        self.assertIn("--orcarouter-login", message)
+
+    def test_reauth_state_blocks_a_known_dead_key(self):
+        from unittest.mock import patch
+
+        config = self._config(ORCAROUTER_AUTH_STATE=REAUTH_NEEDED)
+        with patch.dict("core.config.CONFIG", config, clear=True):
+            with self.assertRaises(OrcaRouterError) as ctx:
+                LLMTuner("", "", "orcarouter/auto", PROVIDER_ID)
+        self.assertIn("--orcarouter-login", str(ctx.exception))
+
+    def test_doctor_discovers_models_on_the_api_origin(self):
+        endpoint, headers = models_endpoint(PROVIDER_ID, "", FAKE_KEY)
+        self.assertEqual(endpoint, "https://api.orcarouter.ai/v1/models")
+        self.assertEqual(headers["Authorization"], f"Bearer {FAKE_KEY}")
+        self.assertNotIn("www.orcarouter.ai", endpoint)
+
+
+# ---------------------------------------------------------------------------
+# Model catalog
+# ---------------------------------------------------------------------------
+
+class CatalogTests(unittest.TestCase):
+    def _models(self):
+        return [
+            model
+            for model in (
+                orcarouter.parse_model_record(record) for record in ALL_RECORDS
+            )
+            if model
+        ]
+
+    def test_record_parsing_keeps_namespace_and_metadata(self):
+        model = orcarouter.parse_model_record(TEXT_MODEL)
+        self.assertEqual(model.id, "openai/gpt-5.5")
+        self.assertEqual(model.context_length, 1_000_000)
+        self.assertEqual(model.input_modalities, ("file", "image", "text"))
+        self.assertEqual(
+            model.reasoning_efforts, ("low", "medium", "high", "xhigh")
+        )
+
+    def test_malformed_records_are_dropped(self):
+        self.assertIsNone(orcarouter.parse_model_record(None))
+        self.assertIsNone(orcarouter.parse_model_record({}))
+        self.assertIsNone(orcarouter.parse_model_record({"id": "  "}))
+
+    def test_chat_filter_excludes_media_only_endpoints(self):
+        ids = [m.id for m in orcarouter.filter_models(self._models(), CAPABILITY_CHAT)]
+        self.assertIn("openai/gpt-5.5", ids)
+        self.assertIn("deepseek/deepseek-v4-pro", ids)
+        for excluded in (
+            IMAGE_GEN_MODEL["id"],
+            EMBEDDING_MODEL["id"],
+            VIDEO_MODEL["id"],
+            RERANK_MODEL["id"],
+            NO_ENDPOINT_MODEL["id"],
+        ):
+            self.assertNotIn(excluded, ids)
+
+    def test_multimodal_filter_fails_closed(self):
+        models = self._models()
+        chat = orcarouter.filter_models(models, CAPABILITY_CHAT)
+        self.assertIn("deepseek/deepseek-v4-pro", [m.id for m in chat])
+
+        with_image = orcarouter.filter_models(
+            models, CAPABILITY_CHAT, required_modalities=["image"]
+        )
+        ids = [m.id for m in with_image]
+        self.assertEqual(ids, ["openai/gpt-5.5"])
+
+        # A model that declares nothing is not assumed to accept images.
+        with_video = orcarouter.filter_models(
+            models, CAPABILITY_CHAT, required_modalities=["video"]
+        )
+        self.assertEqual(with_video, [])
+
+    def test_each_capability_filters_independently(self):
+        models = self._models()
+        self.assertEqual(
+            [m.id for m in orcarouter.filter_models(models, CAPABILITY_EMBEDDING)],
+            [EMBEDDING_MODEL["id"]],
+        )
+        self.assertEqual(
+            [m.id for m in orcarouter.filter_models(models, CAPABILITY_IMAGE)],
+            [IMAGE_GEN_MODEL["id"]],
+        )
+        self.assertEqual(
+            [m.id for m in orcarouter.filter_models(models, CAPABILITY_VIDEO)],
+            [VIDEO_MODEL["id"]],
+        )
+        self.assertEqual(
+            [m.id for m in orcarouter.filter_models(models, CAPABILITY_RERANK)],
+            [RERANK_MODEL["id"]],
+        )
+
+    def test_live_discovery_is_authoritative_and_not_merged_with_the_seed(self):
+        credential = OrcaRouterCredential(api_key=FAKE_KEY, source="api_key")
+        result = orcarouter.fetch_catalog(
+            credential,
+            orcarouter.resolve_origins({}, environ={}),
+            opener=fake_fetch(catalog_payload(ALL_RECORDS)),
+        )
+        self.assertFalse(result.degraded)
+        self.assertEqual(result.source, "live")
+        ids = result.id_set()
+        self.assertIn("openai/gpt-5.5", ids)
+        # Seed-only entries must not be injected into a successful result.
+        self.assertNotIn("orcarouter/auto", ids)
+
+    def test_discovery_failure_keeps_the_verified_seed(self):
+        def boom(request, timeout=None):
+            raise OSError("network down")
+
+        credential = OrcaRouterCredential(api_key=FAKE_KEY, source="api_key")
+        result = orcarouter.fetch_catalog(
+            credential, orcarouter.resolve_origins({}, environ={}), opener=boom
+        )
+        self.assertTrue(result.degraded)
+        self.assertEqual(result.source, "fallback")
+        ids = result.id_set()
+        self.assertIn("openai/gpt-5.5", ids)
+        self.assertIn("orcarouter/auto", ids)
+
+    def test_seed_metadata_and_reasoning_ladder_survive_the_fallback(self):
+        result = CatalogResult(
+            models=orcarouter.fallback_catalog(), source="fallback", degraded=True
+        )
+        by_id = {model.id: model for model in result.models}
+        gpt = by_id["openai/gpt-5.5"]
+        self.assertEqual(
+            gpt.reasoning_efforts, ("low", "medium", "high", "xhigh")
+        )
+        self.assertTrue(gpt.supports_image_input)
+        self.assertIsNotNone(gpt.context_length)
+        # Every seeded entry records where it was verified.
+        for entry in orcarouter.VERIFIED_FALLBACK_CATALOG:
+            self.assertTrue(entry.source.startswith("https://api.orcarouter.ai/"))
+            self.assertTrue(entry.verified_at)
+
+    def test_fallback_filtering_still_applies_per_capability(self):
+        result = CatalogResult(
+            models=orcarouter.fallback_catalog(), source="fallback", degraded=True
+        )
+        text_ids = [m.id for m in result.for_capability(CAPABILITY_CHAT)]
+        self.assertIn("deepseek/deepseek-v4-pro", text_ids)
+        image_ids = [
+            m.id
+            for m in result.for_capability(
+                CAPABILITY_CHAT, required_modalities=["image"]
+            )
+        ]
+        # deepseek-v4-pro is seeded text-only, so it must drop out.
+        self.assertNotIn("deepseek/deepseek-v4-pro", image_ids)
+        self.assertIn("openai/gpt-5.5", image_ids)
+
+    def test_a_401_from_discovery_is_reported_without_the_key(self):
+        def opener(request, timeout=None):
+            return fake_fetch({}, status=401)(request, timeout)
+
+        credential = OrcaRouterCredential(api_key=FAKE_KEY, source="api_key")
+        result = orcarouter.fetch_catalog(
+            credential, orcarouter.resolve_origins({}, environ={}), opener=opener
+        )
+        self.assertTrue(result.degraded)
+        self.assertIn("401", result.error)
+        self.assertNotIn(FAKE_KEY, result.error)
+
+    def test_discovery_requires_a_credential(self):
+        result = orcarouter.fetch_catalog(
+            OrcaRouterCredential(api_key="", source=""),
+            orcarouter.resolve_origins({}, environ={}),
+        )
+        self.assertTrue(result.degraded)
+
+    def test_requested_capability_is_sent_as_a_query_parameter(self):
+        seen = {}
+
+        def opener(request, timeout=None):
+            seen["url"] = request.full_url
+            seen["auth"] = request.get_header("Authorization")
+            return fake_fetch(catalog_payload(ALL_RECORDS))(request, timeout)
+
+        credential = OrcaRouterCredential(api_key=FAKE_KEY, source="api_key")
+        orcarouter.fetch_catalog(
+            credential,
+            orcarouter.resolve_origins({}, environ={}),
+            capability=CAPABILITY_CHAT,
+            opener=opener,
+        )
+        self.assertEqual(
+            seen["url"], "https://api.orcarouter.ai/v1/models?capability=chat"
+        )
+        self.assertEqual(seen["auth"], f"Bearer {FAKE_KEY}")
+
+
+# ---------------------------------------------------------------------------
+# Selector
+# ---------------------------------------------------------------------------
+
+class SelectorTests(unittest.TestCase):
+    def _state(self):
+        from sim.orcarouter_gui import ModelSelectorState
+
+        state = ModelSelectorState()
+        state.set_catalog(
+            CatalogResult(
+                models=[
+                    orcarouter.parse_model_record(TEXT_MODEL),
+                    orcarouter.parse_model_record(TEXT_ONLY_MODEL),
+                    orcarouter.parse_model_record(IMAGE_GEN_MODEL),
+                ],
+                source="live",
+                degraded=False,
+            )
+        )
+        return state
+
+    def test_options_come_from_the_catalog_not_a_hand_written_list(self):
+        state = self._state()
+        self.assertEqual(
+            state.option_ids(), ["openai/gpt-5.5", "deepseek/deepseek-v4-pro"]
+        )
+
+    def test_no_options_when_orcarouter_is_not_selected(self):
+        state = self._state()
+        state.set_provider("openai")
+        self.assertEqual(state.option_ids(), [])
+
+    def test_attaching_an_image_narrows_options_and_clears_a_stale_value(self):
+        state = self._state()
+        self.assertTrue(state.select("deepseek/deepseek-v4-pro"))
+        state.add_modality("image")
+        self.assertEqual(state.option_ids(), ["openai/gpt-5.5"])
+        # The text-only model is no longer compatible: cleared, with a notice.
+        self.assertEqual(state.selected, "")
+        self.assertIn("no longer available", state.notice)
+
+    def test_selecting_an_incompatible_model_is_refused(self):
+        state = self._state()
+        state.add_modality("image")
+        self.assertFalse(state.select("deepseek/deepseek-v4-pro"))
+        self.assertEqual(state.selected, "")
+
+    def test_provider_change_recomputes_the_options(self):
+        state = self._state()
+        state.set_provider("orcarouter_oauth")
+        self.assertTrue(state.options())
+        state.set_provider("anthropic")
+        self.assertEqual(state.options(), [])
+
+    def test_restored_selection_is_revalidated(self):
+        state = self._state()
+        self.assertTrue(state.restore_selected("openai/gpt-5.5"))
+        self.assertFalse(state.restore_selected("google/imagen-4.0-generate-001"))
+        self.assertEqual(state.selected, "")
+
+    def test_degraded_catalog_is_reported_and_marked(self):
+        from sim.orcarouter_gui import ModelSelectorState
+
+        state = ModelSelectorState()
+        state.set_catalog(
+            CatalogResult(
+                models=orcarouter.fallback_catalog(),
+                source="fallback",
+                degraded=True,
+                error="network down",
+            )
+        )
+        self.assertTrue(state.degraded)
+        note = state.status_note()
+        self.assertIn("verified fallback catalog", note)
+        # The verified seed is still offered, and it never looks live.
+        self.assertIn("openai/gpt-5.5", [m.id for m in state.options()])
+
+    def test_empty_state_explains_why_nothing_matches(self):
+        state = self._state()
+        state.set_capability("embedding")
+        self.assertEqual(state.option_ids(), [])
+        self.assertIn("embedding", state.status_note())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tuner.py
+++ b/tuner.py
@@ -15,12 +15,14 @@ from __future__ import annotations
 import argparse
 import time
 import traceback
+import webbrowser
 from typing import Any, Dict, List, Optional
 
 from core.config import CONFIG, initialize_runtime_config
 from core.console import choose_ui_mode, warn_tui_fallback
 from hw.bridge import SerialBridge, safe_pause, select_serial_port
 from hw.profiles import DEFAULT_HARDWARE_PROFILE, normalize_hardware_profile
+from llm import orcarouter
 from llm.client import LLMTuner
 from core.tuning_engine import run_tuning_engine
 from core.adapters import HardwareEnv
@@ -51,6 +53,54 @@ def build_parser() -> argparse.ArgumentParser:
         "--plain",
         action="store_true",
         help="Disable the Textual dashboard and use plain console logs.",
+    )
+    # The two OrcaRouter entry points, side by side.  --orcarouter-login is
+    # OAuth 2.0 + PKCE and issues a key; --orcarouter-key accepts one the
+    # user already holds.  Neither replaces the other.
+    parser.add_argument(
+        "--orcarouter-login",
+        action="store_true",
+        help=(
+            "Sign in to OrcaRouter with OAuth 2.0 + PKCE and store the issued "
+            "API key. No browser available? Add --orcarouter-flow B to paste "
+            "a code instead."
+        ),
+    )
+    parser.add_argument(
+        "--orcarouter-key",
+        metavar="SK_ORCA_KEY",
+        help=(
+            "Store an existing OrcaRouter API key (sk-orca-...) and switch the "
+            "provider to OrcaRouter - API. Pair it with --orcarouter-login's "
+            "sibling entry point rather than replacing it."
+        ),
+    )
+    parser.add_argument(
+        "--orcarouter-flow",
+        choices=("A", "B"),
+        default="A",
+        help=(
+            "PKCE delivery: A = loopback redirect (default, needs a browser "
+            "and a free local port), B = out-of-band code shown on screen."
+        ),
+    )
+    parser.add_argument(
+        "--orcarouter-status",
+        action="store_true",
+        help="Show the stored OrcaRouter credential without printing the key.",
+    )
+    parser.add_argument(
+        "--orcarouter-settings",
+        action="store_true",
+        help=(
+            "Open the local OrcaRouter settings page: paste or clear an API "
+            "key, start the PKCE login, and pick a model from the live catalog."
+        ),
+    )
+    parser.add_argument(
+        "--orcarouter-logout",
+        action="store_true",
+        help="Clear the stored OrcaRouter credential.",
     )
     return parser
 
@@ -298,8 +348,129 @@ def run_hardware_tuner(
         return {"completed_reason": "error", "error": str(exc)}
 
 
+def _apply_orcarouter_credential(credential) -> None:
+    """Persist a credential into the config store every provider already uses."""
+    from core.config import save_config
+
+    store = orcarouter.OrcaRouterCredentialStore(CONFIG)
+    record = store.save(credential)
+    # Selecting the provider is part of the definition: a provider block that
+    # nothing points at would leave the tool on its built-in default.
+    if record.source == orcarouter.PROVIDER_ID_PKCE:
+        CONFIG["LLM_PROVIDER"] = orcarouter.PROVIDER_ID_PKCE
+    else:
+        CONFIG["LLM_PROVIDER"] = orcarouter.PROVIDER_ID
+    if not str(CONFIG.get("LLM_MODEL_NAME", "")).strip() or CONFIG.get(
+        "LLM_MODEL_NAME"
+    ) == "gpt-4o":
+        CONFIG["LLM_MODEL_NAME"] = "orcarouter/auto"
+    CONFIG["LLM_API_BASE_URL"] = orcarouter.resolve_origins(CONFIG).api_base
+    save_config(verbose=True)
+    print(
+        f"[OK] OrcaRouter credential stored via {record.source} "
+        f"(key={record.masked()}, generation={record.generation})."
+    )
+    print(
+        "[INFO] Provider set to "
+        f"{CONFIG['LLM_PROVIDER']}; model {CONFIG['LLM_MODEL_NAME']}. "
+        "Run `python tuner.py --orcarouter-status` to review it."
+    )
+
+
+def run_orcarouter_command(args) -> int:
+    """The two OrcaRouter entry points, plus status and logout."""
+    from core.config import save_config
+
+    initialize_runtime_config(create_if_missing=True, verbose=False)
+    store = orcarouter.OrcaRouterCredentialStore(CONFIG)
+    origins = orcarouter.resolve_origins(CONFIG)
+
+    if args.orcarouter_status:
+        record = store.load()
+        if not record.is_set:
+            print("[INFO] No OrcaRouter credential stored.")
+            return 0
+        print("OrcaRouter credential")
+        print(f"  api_key     : {record.masked()}")
+        print(f"  auth_method : {record.source or 'unknown'}")
+        print(f"  scope       : {record.scope or '(not recorded)'}")
+        print(f"  state       : {record.state}")
+        print(f"  auth origin : {origins.auth_base}")
+        print(f"  api origin  : {origins.api_base}")
+        return 0
+
+    if args.orcarouter_logout:
+        record = store.clear()
+        save_config(verbose=True)
+        print(f"[OK] Cleared the stored OrcaRouter credential (generation {record.generation}).")
+        return 0
+
+    if args.orcarouter_key:
+        key = str(args.orcarouter_key)
+        credential = orcarouter.ApiKeyCredentialSource(api_key=key).acquire(
+            on_hint=lambda message: print(f"[WARN] {message}")
+        )
+        _apply_orcarouter_credential(credential)
+        return 0
+
+    if args.orcarouter_settings:
+        from core.config import save_config
+        from sim.orcarouter_gui import (
+            OrcaRouterCatalogService,
+            OrcaRouterSettingsServer,
+        )
+
+        service = OrcaRouterCatalogService(CONFIG, origins=origins)
+        with OrcaRouterSettingsServer(
+            CONFIG, service=service, persist=save_config
+        ) as server:
+            url = server.base_url
+            print(f"[INFO] OrcaRouter settings: {url}")
+            print(
+                "[INFO] Paste an existing API key, or use Connect with OrcaRouter "
+                "to authorize in a browser. Press Ctrl+C when you are done."
+            )
+            try:
+                webbrowser.open(url)
+            except Exception:
+                pass
+            try:
+                while True:
+                    time.sleep(0.5)
+            except KeyboardInterrupt:
+                print("\n[INFO] Closing the OrcaRouter settings page.")
+        return 0
+
+    if args.orcarouter_login:
+        flow = str(args.orcarouter_flow or "A").upper()
+        source = orcarouter.PKCECredentialSource(
+            origins=origins,
+            flow=flow,
+            open_browser=webbrowser.open,
+        )
+        try:
+            credential = source.acquire(on_hint=lambda message: print(f"[INFO] {message}"))
+        except orcarouter.OrcaRouterError as exc:
+            print(f"[ERROR] OrcaRouter login failed: {exc}")
+            return 1
+        _apply_orcarouter_credential(credential)
+        return 0
+
+    print("Nothing to do. Use --orcarouter-login, --orcarouter-key, "
+          "--orcarouter-status or --orcarouter-logout.")
+    return 0
+
+
 def main(argv: Optional[List[str]] = None) -> None:
     args = build_parser().parse_args(argv)
+    if (
+        args.orcarouter_login
+        or args.orcarouter_key
+        or args.orcarouter_status
+        or args.orcarouter_logout
+        or args.orcarouter_settings
+    ):
+        raise SystemExit(run_orcarouter_command(args))
     result = run_hardware_tuner(args.serial_port, force_plain=args.plain)
     if isinstance(result, dict) and result.get("completed_reason") in {"error", "keyboard_interrupt"}:
         safe_pause("Press Enter to exit...")


### PR DESCRIPTION
## What

Adds OrcaRouter as an optional, first-class provider with **two explicit authentication choices** — paste an existing API key, or authorize with your own OrcaRouter account — without touching any existing provider, the tuning loop, or the PID safety layer.

Closes the gap noted in #47. The maintainer asked for a focused PR against `dev` that reuses the existing OpenAI-compatible transport rather than adding a separate implementation or dependency; that is exactly what this is. It goes beyond #47's proposed doc-only scope because OrcaRouter must ship as a named provider with a real model catalog and both credential entries.

| | |
| :--- | :--- |
| Provider (API key) | `orcarouter` — paste an `sk-orca-…` key |
| Provider (account login) | `orcarouter_oauth` — OAuth 2.0 + PKCE issues the key |
| Inference base | `https://api.orcarouter.ai/v1` |
| Auth origin | `https://www.orcarouter.ai` (authorize `/auth`, exchange `/api/v1/auth/keys`) |
| Closest existing provider followed | the `openai` / `openai_claude` OpenAI-compatible transport in `llm/client.py` and `llm/providers.py` |

**Affiliation disclosure:** I'm an engineer on the OrcaRouter team. This is made on behalf of OrcaRouter, coordinating with the maintainer's guidance in #47.

### Files

- `llm/orcarouter.py` (new) — origins, the credential seam, credential lifecycle, capability-filtered model discovery + verified cold-start catalog.
- `llm/client.py` — `orcarouter` / `orcarouter_oauth` resolve origins and credential through that seam, then reuse the **unchanged** OpenAI-compatible transport (`self.provider = "openai"`).
- `tuner.py` — `--orcarouter-key`, `--orcarouter-login [--orcarouter-flow A|B]`, `--orcarouter-status`, `--orcarouter-logout`, `--orcarouter-settings`.
- `sim/orcarouter_gui.py` (new) — shared model-selector state, the loopback settings surface, and a dashboard panel (`o` hotkey).
- `core/config.py`, `core/doctoring.py` — OrcaRouter config slots; `doctor.py` model reachability on the API origin.
- `README.md`, `docs/en-US/README.md`, `config.example.json`.
- `tests/test_orcarouter_provider.py`, `tests/test_orcarouter_gui.py` (new).

No new dependency: SHA-256 and base64url come from the standard library.

## AI input points covered

This project has one LLM input point (text chat/completion driving PID tuning), reached from several entry points. All of them go through `llm/client.py`, so all are covered by the single provider wiring:

| Entry point | Covered |
| :--- | :--- |
| Hardware tuning loop (`tuner.py`) | yes |
| Python simulator (`simulator.py`) | yes |
| Simulink/MATLAB mode (`system_id.py`) | yes |
| Pre-tuning conversation (`sim/pre_tuning_dialog.py`) | yes |
| Benchmark harness (`benchmark.py`) | yes |
| `doctor.py` reachability check | yes — `/models` on the API origin |

There is no image-generation, embedding, video, rerank, or multimodal-upload entry point in this repository today, so no other input point was left unwired. The catalog layer already filters those capabilities (`filter_models`), so a future multimodal entry point has the filtering it needs; the multimodal path is exercised in the UI evidence below.

## How the credential works

Both entries are adapters on one seam (`CredentialSource`), and both produce the same `OrcaRouterCredential`. The transport and the model catalog never learn which one was used.

- **API key** (`orcarouter`): stored in `config.json` / `ORCAROUTER_API_KEY` — the same place every other provider secret already lives. No new secret store. Supports update and clear, and the doctor's existing `mask_secret` redaction is reused for display. A non-`sk-orca-` prefix is a warning, not a rejection: the prefix is not proof of validity, so the first real request establishes it.
- **Account login** (`orcarouter_oauth`): OAuth 2.0 + PKCE, **Flow A (loopback redirect)** by default, **Flow B (out-of-band code)** via `--orcarouter-flow B`. Flow A was chosen as the default because this is a local desktop/CLI tool that can listen on `127.0.0.1`, so the one-click path works; Flow B is the documented fallback for SSH/containers because there is no callback to register. Always `S256` — a fresh verifier and state per attempt from a cryptographic RNG, the verifier never leaves the process and never appears in a URL, log, or error message. The listener compares `state` with `hmac.compare_digest` before trusting the code. No client secret is involved. Flow C (device grant) is **not** implemented — it is optional and Flow B already covers headless clients.

**The issued key is durable, not a refresh token.** It is a normal OrcaRouter key that belongs to the user: billed to their account, listed in their console, revocable from their authorized-apps page. The tool reuses the stored key until OrcaRouter revokes it; it never re-authorizes on every launch and there is no fabricated refresh grant anywhere in the diff. A `401` from the relay marks **exactly the credential generation that made the rejected request** as `needs_reauth`; a late response from an older generation cannot poison a newly issued key, and the old secret is deliberately retained until a successful new login replaces it.

`ORCA_BASE_URL` (shared self-hosted base) plus explicit `ORCA_AUTH_BASE_URL` / `ORCA_API_BASE_URL` overrides are supported with the explicit values winning. The openid-configuration discovery path from the integration guide was not used; the documented fixed paths are.

## Models

The model list is read from the live catalog at `GET https://api.orcarouter.ai/v1/models`, filtered per capability, and never free text. Vendor namespaces are preserved (`openai/gpt-5.5`, `anthropic/claude-opus-4.8`).

- Text chat keeps models whose `supported_endpoint_types` includes at least one of `openai` / `anthropic` / `gemini` / `openai-response`, and excludes image-generation, openai-video, jina-rerank and embeddings-only routes. Models with **no** endpoint declaration are excluded rather than guessed at.
- Multimodal understanding requires chat first, then an explicit `architecture.input_modalities` entry for the modality actually attached. Undeclared modalities fail closed.
- Embedding / image / video / rerank filter on their own endpoint type.
- Changing provider, task type, or attachments recomputes the option list; a selection that stops being compatible is cleared with a notice instead of being silently kept.
- On discovery failure the tool falls back to a small **verified** catalog and shows a degraded state. A successful live result is authoritative and the seed is never merged into it. The seed preserves the verified context windows and input modalities, including the `low`/`medium`/`high`/`xhigh` reasoning ladder on `openai/gpt-5.5`.

The API key stays server-side: in the settings surface the browser receives only model metadata and a masked key, and the key is never placed in a URL.

## Testing

Commands and observed results. Everything below was run on this branch, at head `fe03a03`, on top of `dev` @ `d885cd6`.

```
$ python3 -m pytest -q
444 passed, 11 subtests passed in 24.41s

$ python3 -m pytest tests/test_orcarouter_provider.py tests/test_orcarouter_gui.py -q
83 passed in 13.00s
```

`git status --porcelain` is empty; `python3 -m compileall` is clean. The repository ships no linter/formatter/typecheck configuration (`ruff`, `flake8`, `pyproject.toml`, `setup.cfg`, and CI config are all absent), so there is no repo-mandated lint gate to run.

What the new tests actually assert:

- both entries are registered and selectable, and both route inference to `https://api.orcarouter.ai/v1` with Bearer auth;
- both adapters yield the **same** credential type and the downstream transport/model path is identical for each (`test_downstream_does_not_care_which_adapter_produced_the_key`);
- PKCE uses a fresh verifier/state per attempt and sends only an S256 challenge; the challenge equals `base64url(sha256(verifier))` with no padding;
- Flow A is driven end-to-end through the real adapter against a **local fake auth server** — authorize → loopback callback → exchange → persist — including a `state` mismatch that never reaches the exchange, a denial, and a timeout. Flow B is driven the same way.
- the exchange posts to `https://www.orcarouter.ai/api/v1/auth/keys` and the verifier/key never appear in the authorize URL, in exceptions, or in `repr()`;
- discovery and the doctor's models endpoint use the API origin only; auth uses the auth origin only;
- a revoked durable key becomes `needs_reauth` with no refresh attempt, and a stale generation's `401` cannot mark a newer credential;
- capability filtering per entry point, multimodal fail-closed, seed metadata survival, and that a successful live result is not merged with the seed;
- the selector recomputes on provider/attachment change, clears an incompatible selection, and rejects restoring it;
- the settings surface shows both entries, the key control is `type="password"`, the model control is a real `role=listbox` (not a text field), the page never contains the stored key, and `pagehide` releases busy state and fires the server cancellation with `keepalive` so a second login can start without a remount.

### Live verification against the real API

Run through the **new provider code path**, not a standalone curl:

- `GET https://api.orcarouter.ai/v1/models` with Bearer auth → `200`, **208** models returned; `supported_endpoint_types` and `architecture.input_modalities` present as documented.
- Streaming completion through `LLMTuner(provider="orcarouter")` using `orcarouter/auto` reached the relay over `POST {base}/chat/completions` with `stream: true` and returned content `OK`.
- After filtering: **161** chat-capable models, **122** of those declaring `image` input, and **0** non-chat routes (embeddings/image-generation/video/rerank) leaking into the text list.

### What is *not* verified here

I did not perform a human consent-screen approval or a real revocation. Both require a person to click through the OrcaRouter consent screen, and I will not fabricate that. Flow A/B are covered end-to-end against a local fake auth server instead. A maintainer with an account can confirm the consent screen, the denial path, and the revocation → reauth transition with the self-test checklist in the integration guide using `python tuner.py --orcarouter-login`.

## UI

Real local screenshots, captured by `scripts/capture_orcarouter_evidence.py` (Playwright + Chromium against the project's own settings surface, not a mockup). The model list in these images is the live catalog fetched server-side with a test key.

- `auth-methods` — both entries visible side by side; the key control is a masked password input, both control sets enabled.
- `text-model-dropdown` — 161 real models, panel width 360, right edge aligned to the trigger (delta 0), opaque background and visible border.
- `multimodal-model-dropdown` — after attaching an image, 122 models, each one explicitly declaring image input in the live catalog.

Textual 8's dashboard has no DOM, so the evidence gate's `role=listbox`/bounding-box assertions are driven against the project's local settings page — a real surface of this program, served on loopback by `sim.orcarouter_gui.py`, alongside the in-dashboard panel reachable with `o`.

## Provider evidence

The official classic mark is referenced from `https://www.orcarouter.ai/orca-logo-classic.png`; the page degrades to an inline vector mark if that asset is unreachable rather than rendering a broken image.

Verified first-hand on **2026-09-11**:

- Inference: `POST https://api.orcarouter.ai/v1/chat/completions` — OpenAI-compatible, returns SSE with `choices[0].delta.content` and a `data: [DONE]` sentinel. Exercised above.
- Model list: `GET https://api.orcarouter.ai/v1/models` — requires `Authorization: Bearer <key>`, returns 208 models with capability metadata. Exercised above.
- Authentication origin: `https://www.orcarouter.ai`, authorize at `/auth`, exchange at `/api/v1/auth/keys` (note: the relay's `/v1/auth/keys` is a 404). Used by the code and asserted by tests.

Provided by OrcaRouter for a maintainer to review (not independently re-verified in this run): the consent/authorization, exchange, revocation and account-management documentation; the terms of service and operating legal entity; and routing/resale authorization covering the aggregator path. Revocation and account management live at `https://www.orcarouter.ai/console/authorized-apps`.

- Maintenance owner for this integration: the OrcaRouter team (contributor of this PR).
- Verification date of the endpoint evidence above: 2026-09-11.

## Notes for review

- This PR does not touch CI configuration, the licence, lockfiles, or unrelated formatting.
- Authentication is a credential-destination change, so it may trip the repository's sponsorship gate; that is expected and a maintainer needs to review the exact head commit. I have not applied any maintainer-only label.
- `README.md` and `docs/en-US/README.md` are updated in the same change; `config.example.json` is kept byte-identical to the generated default (`tests/test_regression.py::test_generated_config_matches_template` enforces this).

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents, with adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

<!-- orcarouter-operation:task:6134:create_pr -->